### PR TITLE
Fix API URL and key for stage environment

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
-REACT_APP_API_URL=https://api.zenya.app
-REACT_APP_API_KEY=
+REACT_APP_API_URL=https://api-stage.zenya.com.mx
+REACT_APP_API_KEY=zenya-api-prod-2026

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -7,17 +7,12 @@ runConfig:
   # cpu: 1
   # memoryMiB: 512
 
-# Environment variables and secrets.
-# env:
-  # Configure environment variables.
-  # See https://firebase.google.com/docs/app-hosting/configure#user-defined-environment
-  # - variable: MESSAGE
-  #   value: Hello world!
-  #   availability:
-  #     - BUILD
-  #     - RUNTIME
-
-  # Grant access to secrets in Cloud Secret Manager.
-  # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
-  # - variable: MY_SECRET
-  #   secret: mySecretRef
+env:
+  - variable: REACT_APP_API_URL
+    value: https://api-stage.zenya.com.mx
+    availability:
+      - BUILD
+  - variable: REACT_APP_API_KEY
+    value: zenya-api-prod-2026
+    availability:
+      - BUILD


### PR DESCRIPTION
## Summary
- Sets `REACT_APP_API_URL=https://api-stage.zenya.com.mx` and `REACT_APP_API_KEY=zenya-api-prod-2026` in `apphosting.yaml` (injected at build time by Firebase App Hosting)
- Updates `.env.production` to match as a local fallback
- Fixes requests going to the wrong URL (`api.zenya.app`) with `dev-key`

## Test plan
- [ ] Merge and confirm Firebase redeploys
- [ ] Open the stage app and verify Network tab shows requests going to `api-stage.zenya.com.mx` with the correct key
- [ ] Confirm Overview KPIs, Clients list, and Appointments load real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)