### PR TITLE
Remove mock data — wire API or show empty states

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ const NAV = [
   { id: 'services', label: 'Servicios', icon: 'Sparkles' },
   { id: 'staff', label: 'Personal', icon: 'Users' },
   { id: 'clients', label: 'Clientas', icon: 'Heart' },
-  { id: 'appointments', label: 'Citas', icon: 'Calendar', badge: '8' },
+  { id: 'appointments', label: 'Citas', icon: 'Calendar' },
   { id: 'settings', label: 'Ajustes', icon: 'Settings' },
 ];
 

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import D from '../mocks/data';
 import { api } from '../lib/api';
 import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
@@ -8,7 +7,6 @@ import Donut from '../components/charts/donut';
 import BarChart from '../components/charts/bar-chart';
 import DataTable from '../components/widgets/data-table';
 import Avatar from '../components/ui/avatar';
-import ProgressBar from '../components/charts/progress-bar';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 
@@ -33,17 +31,11 @@ const Clients = () => {
           value={totalClients.toLocaleString('es-MX')}
           caption="en base de datos"
           icon="Users"
-          spark={D.series(71, 12, 350, 50, 4)}
+          spark={[]}
           sparkColor="var(--chart-1)"
         />
-        <StatCard
-          label="Clientas VIP"
-          value={D.loyaltySegments.find((s) => s.name === 'VIP').count}
-          delta={5.3}
-          caption="41% del ingreso"
-          icon="Star"
-        />
-        <StatCard label="Retención" value="73%" delta={2.1} caption="vs mes anterior" icon="TrendingUp" />
+        <StatCard label="Clientas VIP" value="—" caption="sin datos" icon="Star" />
+        <StatCard label="Retención" value="—" caption="sin datos" icon="TrendingUp" />
         <StatCard
           label="Ticket promedio"
           value={kpis ? money(kpis.avg_ticket) : '—'}
@@ -56,69 +48,30 @@ const Clients = () => {
         <Card eyebrow="Segmentación" title="Lealtad de clientas">
           <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
             <Donut
-              data={D.loyaltySegments}
+              data={[]}
               size={150}
               thickness={20}
-              centerValue={totalClients || D.totals.activeClients}
+              centerValue={totalClients || 0}
               centerLabel="clientes"
             />
-            <div style={{ flex: 1, minWidth: 120 }}>
-              {D.loyaltySegments.map((seg, i) => (
-                <div
-                  key={seg.name}
-                  style={{
-                    padding: '7px 0',
-                    borderBottom: i < D.loyaltySegments.length - 1 ? '1px solid var(--border-subtle)' : 'none',
-                  }}
-                >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
-                      <span style={{ width: 10, height: 10, borderRadius: 3, background: seg.color, flexShrink: 0 }} />
-                      <span
-                        style={{
-                          fontFamily: 'var(--font-sans)',
-                          fontSize: 'var(--text-sm)',
-                          color: 'var(--text-body)',
-                        }}
-                      >
-                        {seg.name}
-                      </span>
-                    </div>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <span
-                        style={{
-                          fontFamily: 'var(--font-sans)',
-                          fontSize: 'var(--text-sm)',
-                          fontWeight: 'var(--fw-semibold)',
-                          color: 'var(--text-heading)',
-                        }}
-                      >
-                        {seg.count}
-                      </span>
-                      <span
-                        style={{
-                          fontFamily: 'var(--font-sans)',
-                          fontSize: 'var(--text-xs)',
-                          color: 'var(--text-muted)',
-                        }}
-                      >
-                        {Math.round(seg.pct * 100)}%
-                      </span>
-                    </div>
-                  </div>
-                  <ProgressBar ratio={seg.pct} color={seg.color} height={4} />
-                </div>
-              ))}
+            <div
+              style={{
+                flex: 1,
+                minWidth: 120,
+                padding: '12px 0',
+                textAlign: 'center',
+                color: 'var(--text-muted)',
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+              }}
+            >
+              Sin datos de segmentación
             </div>
           </div>
         </Card>
 
         <Card eyebrow="Frecuencia" title="Visitas por clienta">
-          <BarChart
-            data={D.visitFreq.map((f, i) => ({ label: f.label, value: f.value, color: D.CHART[i % D.CHART.length] }))}
-            height={200}
-            yFormat={(v) => v}
-          />
+          <BarChart data={[]} height={200} yFormat={(v) => v} />
         </Card>
       </div>
 

--- a/src/pages/overview.jsx
+++ b/src/pages/overview.jsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react';
-import D from '../mocks/data';
 import { api } from '../lib/api';
 import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
@@ -8,12 +7,12 @@ import AreaChart from '../components/charts/area-chart';
 import RankRow from '../components/widgets/rank-row';
 import Avatar from '../components/ui/avatar';
 import LegendRow from '../components/ui/legend-row';
-import InsightCard from '../components/ui/insight-card';
 import SegmentedControl from '../components/ui/segmented-control';
 import { Clock } from 'lucide-react';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
+const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
 
 function thisMonthRange() {
   const now = new Date();
@@ -41,7 +40,8 @@ const Overview = () => {
   const { data: staffData } = useApi(() => api.staffPerformance(thisMonth), []);
   const { data: recentBookings } = useApi(() => api.bookings({ ...thisMonth, limit: 6 }), []);
 
-  const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
+  const revDelta =
+    kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const apptDelta =
     kpis && kpisPrev?.bookings_count
       ? ((kpis.bookings_count - kpisPrev.bookings_count) / kpisPrev.bookings_count) * 100
@@ -52,6 +52,8 @@ const Overview = () => {
   const chartData = useMemo(() => revByDay?.map((r) => r.revenue) ?? [], [revByDay]);
   const chartLabels = useMemo(() => revByDay?.map((r) => `Día ${new Date(r.date).getDate()}`) ?? [], [revByDay]);
   const maxServiceRev = topServices?.length ? Math.max(...topServices.map((s) => s.revenue)) : 1;
+  const bookings = recentBookings ?? [];
+  const staff = staffData ?? [];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
@@ -62,7 +64,7 @@ const Overview = () => {
           delta={revDelta}
           caption="vs mes anterior"
           icon="TrendingUp"
-          spark={chartData.length ? chartData : D.series(41, 12, 60000, 20000, 1400)}
+          spark={chartData}
           sparkColor="var(--chart-1)"
         />
         <StatCard
@@ -71,7 +73,7 @@ const Overview = () => {
           delta={apptDelta}
           caption="vs mes anterior"
           icon="Calendar"
-          spark={D.series(42, 12, 450, 100, 10)}
+          spark={[]}
           sparkColor="var(--chart-2)"
         />
         <StatCard
@@ -80,7 +82,7 @@ const Overview = () => {
           delta={ticketDelta}
           caption="vs mes anterior"
           icon="DollarSign"
-          spark={D.series(43, 12, 120, 20, 1)}
+          spark={[]}
           sparkColor="var(--chart-3)"
         />
         <StatCard
@@ -88,7 +90,7 @@ const Overview = () => {
           value={kpis ? kpis.new_clients.toLocaleString('es-MX') : '—'}
           caption="en base de datos"
           icon="Heart"
-          spark={D.series(44, 12, 35, 15, 1)}
+          spark={[]}
           sparkColor="var(--chart-4)"
         />
       </div>
@@ -114,42 +116,35 @@ const Overview = () => {
             items={[{ label: 'Este mes', color: 'var(--chart-1)', line: true }]}
             style={{ marginBottom: 14 }}
           />
-          <AreaChart
-            data={chartData.length ? chartData : D.revToday}
-            labels={chartLabels.length ? chartLabels : D.revToday.map((_, i) => `Día ${i + 1}`)}
-            yFormat={moneyK}
-            height={210}
-          />
+          <AreaChart data={chartData} labels={chartLabels} yFormat={moneyK} height={210} />
         </Card>
 
         <Card eyebrow="Servicios" title="Top servicios">
-          {(topServices ?? D.services.slice(0, 5).map((s) => ({ name: s.name, revenue: s.rev, count: s.count }))).map(
-            (s, i) => (
-              <RankRow
-                key={s.name}
-                rank={i + 1}
-                label={s.name}
-                value={money(s.revenue)}
-                ratio={s.revenue / maxServiceRev}
-                color={D.CHART[i % D.CHART.length]}
-                last={i === 4}
-              />
-            )
-          )}
+          {(topServices ?? []).map((s, i) => (
+            <RankRow
+              key={s.name}
+              rank={i + 1}
+              label={s.name}
+              value={money(s.revenue)}
+              ratio={s.revenue / maxServiceRev}
+              color={CHART[i % CHART.length]}
+              last={i === topServices.length - 1}
+            />
+          ))}
         </Card>
       </div>
 
       <div className="z-2col">
         <Card eyebrow="Hoy" title="Actividad reciente">
           <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
-            {(recentBookings ?? []).map((b, i) => (
+            {bookings.map((b, i) => (
               <div
                 key={b.id}
                 style={{
                   display: 'flex',
                   gap: 12,
                   padding: '10px 0',
-                  borderBottom: i < recentBookings.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+                  borderBottom: i < bookings.length - 1 ? '1px solid var(--border-subtle)' : 'none',
                   alignItems: 'flex-start',
                 }}
               >
@@ -188,66 +183,40 @@ const Overview = () => {
                 </div>
               </div>
             ))}
-            {!recentBookings?.length &&
-              D.activity.map((item, i) => (
-                <div
-                  key={i}
-                  style={{
-                    display: 'flex',
-                    gap: 12,
-                    padding: '10px 0',
-                    borderBottom: i < D.activity.length - 1 ? '1px solid var(--border-subtle)' : 'none',
-                    alignItems: 'flex-start',
-                  }}
-                >
-                  <div
-                    style={{
-                      width: 8,
-                      height: 8,
-                      borderRadius: '50%',
-                      background: item.type === 'paid' ? 'var(--green-500)' : 'var(--amber-500)',
-                      flexShrink: 0,
-                      marginTop: 5,
-                    }}
-                  />
-                  <div style={{ flex: 1 }}>
-                    <div
-                      style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}
-                    >
-                      {item.text}
-                    </div>
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 4,
-                        marginTop: 3,
-                        fontFamily: 'var(--font-sans)',
-                        fontSize: 'var(--text-xs)',
-                        color: 'var(--text-muted)',
-                      }}
-                    >
-                      <Clock size={11} strokeWidth={1.5} />
-                      {item.time}
-                    </div>
-                  </div>
-                </div>
-              ))}
+            {!bookings.length && (
+              <div
+                style={{
+                  padding: '20px 0',
+                  textAlign: 'center',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                }}
+              >
+                Sin actividad reciente
+              </div>
+            )}
           </div>
         </Card>
 
         <Card eyebrow="Análisis" title="Insights">
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {D.insights.map((ins, i) => (
-              <InsightCard key={i} icon={ins.icon} tone={ins.tone} title={ins.title} body={ins.body} />
-            ))}
+          <div
+            style={{
+              padding: '20px 0',
+              textAlign: 'center',
+              color: 'var(--text-muted)',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--text-sm)',
+            }}
+          >
+            Sin insights disponibles
           </div>
         </Card>
       </div>
 
       <Card eyebrow="Personal" title="Rendimiento del equipo">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
-          {(staffData ?? []).map((s, i) => {
+          {staff.map((s, i) => {
             const name = [s.first_name, s.last_name].filter(Boolean).join(' ') || `Profesional ${s.professional_id}`;
             return (
               <div
@@ -258,7 +227,7 @@ const Overview = () => {
                   alignItems: 'center',
                   gap: 14,
                   padding: '12px 0',
-                  borderBottom: i < staffData.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+                  borderBottom: i < staff.length - 1 ? '1px solid var(--border-subtle)' : 'none',
                 }}
               >
                 <Avatar name={name} size="sm" tone={i === 0 ? 'rose' : i === 1 ? 'lavender' : 'ink'} />
@@ -294,6 +263,19 @@ const Overview = () => {
               </div>
             );
           })}
+          {!staff.length && (
+            <div
+              style={{
+                padding: '20px 0',
+                textAlign: 'center',
+                color: 'var(--text-muted)',
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+              }}
+            >
+              Sin datos de personal
+            </div>
+          )}
         </div>
       </Card>
     </div>

--- a/src/pages/revenue.jsx
+++ b/src/pages/revenue.jsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import D from '../mocks/data';
+import { useState, useMemo } from 'react';
+import { api } from '../lib/api';
+import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
 import Card from '../components/ui/card';
 import AreaChart from '../components/charts/area-chart';
@@ -11,8 +12,22 @@ import LegendRow from '../components/ui/legend-row';
 import SegmentedControl from '../components/ui/segmented-control';
 import DeltaBadge from '../components/ui/delta-badge';
 
-const revDelta = ((D.totals.revMonth - D.totals.revPrevMonth) / D.totals.revPrevMonth) * 100;
-const ticketDelta = ((D.totals.avgTicket - D.totals.avgTicketPrev) / D.totals.avgTicketPrev) * 100;
+const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
+const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
+
+function thisMonthRange() {
+  const now = new Date();
+  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+  const to = now.toISOString().slice(0, 10);
+  return { from_date: from, to_date: to };
+}
+
+function prevMonthRange() {
+  const now = new Date();
+  const from = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString().slice(0, 10);
+  const to = new Date(now.getFullYear(), now.getMonth(), 0).toISOString().slice(0, 10);
+  return { from_date: from, to_date: to };
+}
 
 const COLUMNS = [
   { key: 'label', label: 'Día' },
@@ -24,40 +39,46 @@ const COLUMNS = [
 
 const Revenue = () => {
   const [period, setPeriod] = useState('mes');
+  const thisMonth = thisMonthRange();
+  const prevMonth = prevMonthRange();
 
-  const rows = D.dayRows.map((r) => ({ ...r, delta: ((r.cur - r.prev) / r.prev) * 100 }));
+  const { data: kpis } = useApi(() => api.kpis(thisMonth), []);
+  const { data: kpisPrev } = useApi(() => api.kpis(prevMonth), []);
+  const { data: revByDay } = useApi(() => api.revenueByDay(thisMonth), []);
+  const { data: paymentsData } = useApi(() => api.paymentMethodsBreakdown(thisMonth), []);
+
+  const revDelta =
+    kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
+  const ticketDelta =
+    kpis && kpisPrev?.avg_ticket ? ((kpis.avg_ticket - kpisPrev.avg_ticket) / kpisPrev.avg_ticket) * 100 : 0;
+
+  const chartData = useMemo(() => revByDay?.map((r) => r.revenue) ?? [], [revByDay]);
+  const chartLabels = useMemo(() => revByDay?.map((r) => `Día ${new Date(r.date).getDate()}`) ?? [], [revByDay]);
+  const payments = paymentsData ?? [];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
       <div className="z-kpi-grid">
         <StatCard
           label="Ingresos del mes"
-          value={D.money(D.totals.revMonth)}
+          value={kpis ? money(kpis.revenue) : '—'}
           delta={revDelta}
           caption="vs mes anterior"
           icon="TrendingUp"
-          spark={D.series(51, 12, 60000, 20000, 1400)}
+          spark={chartData}
           sparkColor="var(--chart-1)"
         />
         <StatCard
           label="Ticket promedio"
-          value={D.money(D.totals.avgTicket)}
+          value={kpis ? money(kpis.avg_ticket) : '—'}
           delta={ticketDelta}
           caption="vs mes anterior"
           icon="DollarSign"
-          spark={D.series(52, 12, 120, 20, 1)}
+          spark={[]}
           sparkColor="var(--chart-2)"
         />
-        <StatCard
-          label="Mejor día"
-          value={D.money(9200)}
-          delta={9.5}
-          caption="Sábado"
-          icon="Star"
-          spark={D.series(53, 12, 7000, 2000, 100)}
-          sparkColor="var(--chart-3)"
-        />
-        <StatCard label="Meta mensual" value="87%" delta={4.2} caption="$78.5k de $90k" icon="Target" />
+        <StatCard label="Mejor día" value="—" caption="sin datos" icon="Star" />
+        <StatCard label="Meta mensual" value="—" caption="sin configurar" icon="Target" />
       </div>
 
       <div className="z-2col-wide">
@@ -84,60 +105,29 @@ const Revenue = () => {
             ]}
             style={{ marginBottom: 14 }}
           />
-          <AreaChart
-            data={D.revToday}
-            compare={D.revPrev}
-            labels={D.revToday.map((_, i) => `Día ${i + 1}`)}
-            yFormat={D.moneyK}
-            height={220}
-          />
+          <AreaChart data={chartData} labels={chartLabels} yFormat={moneyK} height={220} />
         </Card>
 
         <Card eyebrow="Distribución" title="Por categoría">
           <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 20 }}>
             <Donut
-              data={D.categories}
+              data={[]}
               size={160}
               thickness={22}
-              centerValue={D.moneyK(D.totals.revMonth)}
+              centerValue={kpis ? moneyK(kpis.revenue) : '—'}
               centerLabel="total"
             />
           </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {D.categories.map((cat) => (
-              <div key={cat.name}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <span
-                      style={{
-                        width: 10,
-                        height: 10,
-                        borderRadius: 3,
-                        background: cat.color,
-                        display: 'inline-block',
-                        flexShrink: 0,
-                      }}
-                    />
-                    <span
-                      style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}
-                    >
-                      {cat.name}
-                    </span>
-                  </div>
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-sans)',
-                      fontSize: 'var(--text-sm)',
-                      fontWeight: 'var(--fw-semibold)',
-                      color: 'var(--text-heading)',
-                    }}
-                  >
-                    {D.money(cat.rev)}
-                  </span>
-                </div>
-                <ProgressBar ratio={cat.pct} color={cat.color} height={5} />
-              </div>
-            ))}
+          <div
+            style={{
+              padding: '12px 0',
+              textAlign: 'center',
+              color: 'var(--text-muted)',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--text-sm)',
+            }}
+          >
+            Sin datos por categoría
           </div>
         </Card>
       </div>
@@ -151,48 +141,77 @@ const Revenue = () => {
             ]}
             style={{ marginBottom: 14 }}
           />
-          <GroupedBars data={D.weekCompare} height={200} yFormat={D.moneyK} />
+          <GroupedBars data={[]} height={200} yFormat={moneyK} />
         </Card>
 
         <Card eyebrow="Pagos" title="Métodos de pago">
           <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 20 }}>
-            <Donut data={D.payments.map((p) => ({ value: p.pct, color: p.color }))} size={130} thickness={18} />
+            <Donut
+              data={payments.map((p, i) => ({
+                value: p.percentage ?? p.pct ?? 0,
+                color: `var(--chart-${(i % 5) + 1})`,
+              }))}
+              size={130}
+              thickness={18}
+            />
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            {D.payments.map((p) => (
-              <div key={p.name}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            {payments.length ? (
+              payments.map((p, i) => (
+                <div key={p.method_name ?? p.name ?? i}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <span
+                        style={{
+                          width: 10,
+                          height: 10,
+                          borderRadius: 3,
+                          background: `var(--chart-${(i % 5) + 1})`,
+                          display: 'inline-block',
+                          flexShrink: 0,
+                        }}
+                      />
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-sm)',
+                          color: 'var(--text-body)',
+                        }}
+                      >
+                        {p.method_name ?? p.name ?? '—'}
+                      </span>
+                    </div>
                     <span
                       style={{
-                        width: 10,
-                        height: 10,
-                        borderRadius: 3,
-                        background: p.color,
-                        display: 'inline-block',
-                        flexShrink: 0,
+                        fontFamily: 'var(--font-sans)',
+                        fontSize: 'var(--text-sm)',
+                        fontWeight: 'var(--fw-semibold)',
+                        color: 'var(--text-heading)',
                       }}
-                    />
-                    <span
-                      style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}
                     >
-                      {p.name}
+                      {Math.round((p.percentage ?? p.pct ?? 0) * 100)}%
                     </span>
                   </div>
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-sans)',
-                      fontSize: 'var(--text-sm)',
-                      fontWeight: 'var(--fw-semibold)',
-                      color: 'var(--text-heading)',
-                    }}
-                  >
-                    {Math.round(p.pct * 100)}%
-                  </span>
+                  <ProgressBar
+                    ratio={p.percentage ?? p.pct ?? 0}
+                    color={`var(--chart-${(i % 5) + 1})`}
+                    height={5}
+                  />
                 </div>
-                <ProgressBar ratio={p.pct} color={p.color} height={5} />
+              ))
+            ) : (
+              <div
+                style={{
+                  padding: '12px 0',
+                  textAlign: 'center',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                }}
+              >
+                Sin datos de pagos
               </div>
-            ))}
+            )}
           </div>
         </Card>
       </div>
@@ -200,9 +219,9 @@ const Revenue = () => {
       <Card eyebrow="Detalle" title="Ingresos por día de la semana">
         <DataTable
           columns={COLUMNS}
-          rows={rows}
+          rows={[]}
           renderCell={(row, key) => {
-            if (key === 'cur' || key === 'prev') return D.money(row[key]);
+            if (key === 'cur' || key === 'prev') return money(row[key]);
             if (key === 'delta') return <DeltaBadge value={row.delta} format="percent" size="sm" />;
             return row[key];
           }}

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import D from '../mocks/data';
+import { useState, useMemo } from 'react';
+import { api } from '../lib/api';
+import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
 import Card from '../components/ui/card';
 import RankRow from '../components/widgets/rank-row';
@@ -12,8 +13,17 @@ import DeltaBadge from '../components/ui/delta-badge';
 import LegendRow from '../components/ui/legend-row';
 import SegmentedControl from '../components/ui/segmented-control';
 
-const maxRev = Math.max(...D.services.map((s) => s.rev));
+const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
+const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
+const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
 const MONTHS = ['E', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
+
+function thisMonthRange() {
+  const now = new Date();
+  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+  const to = now.toISOString().slice(0, 10);
+  return { from_date: from, to_date: to };
+}
 
 const COLUMNS = [
   { key: 'name', label: 'Servicio' },
@@ -28,38 +38,64 @@ const COLUMNS = [
 
 const Services = () => {
   const [catFilter, setCatFilter] = useState('Todos');
-  const cats = ['Todos', ...Array.from(new Set(D.services.map((s) => s.cat)))];
-  const filtered = catFilter === 'Todos' ? D.services : D.services.filter((s) => s.cat === catFilter);
+  const thisMonth = thisMonthRange();
 
-  const topRev = D.services.reduce((a, b) => (a.rev > b.rev ? a : b));
-  const topCount = D.services.reduce((a, b) => (a.count > b.count ? a : b));
-  const topAvg = D.services.reduce((a, b) => (a.avg > b.avg ? a : b));
-  const topTrend = D.services.reduce((a, b) => (a.trend > b.trend ? a : b));
+  const { data: rawTopServices } = useApi(() => api.topServices({ ...thisMonth, limit: 20 }), []);
+
+  const services = useMemo(
+    () =>
+      (rawTopServices ?? []).map((s) => ({
+        name: s.name ?? s.service_name ?? '—',
+        cat: s.category ?? '—',
+        provider: s.provider ?? '—',
+        rev: s.revenue ?? 0,
+        count: s.count ?? s.bookings_count ?? 0,
+        avg: s.count ? Math.round((s.revenue ?? 0) / s.count) : 0,
+        trend: s.trend ?? 0,
+        spark: [],
+      })),
+    [rawTopServices]
+  );
+
+  const maxRev = services.length ? Math.max(...services.map((s) => s.rev)) : 1;
+  const maxCount = services.length ? Math.max(...services.map((s) => s.count)) : 1;
+  const cats = ['Todos', ...Array.from(new Set(services.map((s) => s.cat).filter((c) => c !== '—')))];
+  const filtered = catFilter === 'Todos' ? services : services.filter((s) => s.cat === catFilter);
+
+  const topRev = services.length ? services.reduce((a, b) => (a.rev > b.rev ? a : b)) : null;
+  const topCount = services.length ? services.reduce((a, b) => (a.count > b.count ? a : b)) : null;
+  const topAvg = services.length ? services.reduce((a, b) => (a.avg > b.avg ? a : b)) : null;
+  const topTrend = services.length ? services.reduce((a, b) => (a.trend > b.trend ? a : b)) : null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
       <div className="z-kpi-grid">
         <StatCard
           label="Servicio top"
-          value={topRev.name}
-          delta={topRev.trend}
-          caption={D.money(topRev.rev)}
+          value={topRev?.name ?? '—'}
+          delta={topRev?.trend ?? 0}
+          caption={topRev ? money(topRev.rev) : '—'}
           icon="Sparkles"
           numeralStyle="sans"
         />
-        <StatCard label="Más demandado" value={`${topCount.count} citas`} caption={topCount.name} icon="Calendar" />
+        <StatCard
+          label="Más demandado"
+          value={topCount ? `${topCount.count} citas` : '—'}
+          caption={topCount?.name ?? '—'}
+          icon="Calendar"
+        />
         <StatCard
           label="Mayor ticket"
-          value={D.money(topAvg.avg)}
-          delta={topAvg.trend}
-          caption={topAvg.name}
+          value={topAvg ? money(topAvg.avg) : '—'}
+          delta={topAvg?.trend ?? 0}
+          caption={topAvg?.name ?? '—'}
           icon="DollarSign"
         />
         <StatCard
           label="Mayor crecimiento"
-          value={`+${topTrend.trend}%`}
-          delta={topTrend.trend}
-          caption={topTrend.name}
+          value={topTrend ? `+${topTrend.trend}%` : '—'}
+          delta={topTrend?.trend ?? 0}
+          caption={topTrend?.name ?? '—'}
           icon="TrendingUp"
         />
       </div>
@@ -67,13 +103,13 @@ const Services = () => {
       <div className="z-2col">
         <Card eyebrow="Ingresos" title="Por servicio">
           <BarChart
-            data={D.services.map((s, i) => ({
+            data={services.map((s, i) => ({
               label: s.name.split(' ')[0],
               value: s.rev,
-              color: D.CHART[i % D.CHART.length],
+              color: CHART[i % CHART.length],
             }))}
             height={220}
-            yFormat={D.moneyK}
+            yFormat={moneyK}
           />
         </Card>
 
@@ -82,50 +118,50 @@ const Services = () => {
           title="Top servicios"
           action={
             <LegendRow
-              items={D.services
+              items={services
                 .slice(0, 3)
-                .map((s, i) => ({ label: s.name.split(' ')[0], color: D.CHART[i], line: true }))}
+                .map((s, i) => ({ label: s.name.split(' ')[0], color: CHART[i], line: true }))}
             />
           }
         >
           <MultiLine
-            series={D.services.slice(0, 3).map((s, i) => ({ data: s.spark, color: D.CHART[i] }))}
+            series={services.slice(0, 3).map((s, i) => ({ data: s.spark, color: CHART[i] }))}
             labels={MONTHS}
             height={220}
-            yFormat={D.moneyK}
+            yFormat={moneyK}
           />
         </Card>
       </div>
 
       <div className="z-2col">
         <Card eyebrow="Ranking" title="Por ingresos">
-          {D.services.map((s, i) => (
+          {services.map((s, i) => (
             <RankRow
               key={s.name}
               rank={i + 1}
               label={s.name}
               sublabel={s.cat}
-              value={D.money(s.rev)}
+              value={money(s.rev)}
               ratio={s.rev / maxRev}
-              color={D.CHART[i % D.CHART.length]}
-              last={i === D.services.length - 1}
+              color={CHART[i % CHART.length]}
+              last={i === services.length - 1}
             />
           ))}
         </Card>
 
         <Card eyebrow="Ranking" title="Por cantidad">
-          {[...D.services]
+          {[...services]
             .sort((a, b) => b.count - a.count)
             .map((s, i) => (
               <RankRow
                 key={s.name}
                 rank={i + 1}
                 label={s.name}
-                sublabel={`${s.count} citas · ${D.money(s.avg)} avg`}
+                sublabel={`${s.count} citas · ${money(s.avg)} avg`}
                 value={`${s.count}`}
-                ratio={s.count / Math.max(...D.services.map((x) => x.count))}
-                color={D.CHART[i % D.CHART.length]}
-                last={i === D.services.length - 1}
+                ratio={s.count / maxCount}
+                color={CHART[i % CHART.length]}
+                last={i === services.length - 1}
               />
             ))}
         </Card>
@@ -147,8 +183,8 @@ const Services = () => {
           columns={COLUMNS}
           rows={filtered}
           renderCell={(row, key) => {
-            if (key === 'rev') return D.money(row.rev);
-            if (key === 'avg') return D.money(row.avg);
+            if (key === 'rev') return money(row.rev);
+            if (key === 'avg') return money(row.avg);
             if (key === 'cat') return <Badge tone="lavender">{row.cat}</Badge>;
             if (key === 'trend') return <DeltaBadge value={row.trend} format="percent" size="sm" />;
             if (key === 'spark') return <Sparkline data={row.spark} width={72} height={24} color="var(--chart-1)" />;

--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -1,4 +1,6 @@
-import D from '../mocks/data';
+import { useMemo } from 'react';
+import { api } from '../lib/api';
+import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
 import Card from '../components/ui/card';
 import StaffCard from '../components/widgets/staff-card';
@@ -9,10 +11,16 @@ import DataTable from '../components/widgets/data-table';
 import Avatar from '../components/ui/avatar';
 import Badge from '../components/ui/badge';
 
-const maxRev = Math.max(...D.staff.map((s) => s.rev));
-const totalRev = D.staff.reduce((s, m) => s + m.rev, 0);
-const avgRating = (D.staff.reduce((s, m) => s + m.rating, 0) / D.staff.length).toFixed(1);
-const totalAppts = D.staff.reduce((s, m) => s + m.appts, 0);
+const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
+const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
+const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
+
+function thisMonthRange() {
+  const now = new Date();
+  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+  const to = now.toISOString().slice(0, 10);
+  return { from_date: from, to_date: to };
+}
 
 const COLUMNS = [
   { key: 'name', label: 'Empleada' },
@@ -25,40 +33,60 @@ const COLUMNS = [
 ];
 
 const Staff = () => {
-  const topStaff = D.staff[0];
+  const thisMonth = thisMonthRange();
+  const { data: staffData } = useApi(() => api.staffPerformance(thisMonth), []);
+
+  const staff = useMemo(
+    () =>
+      (staffData ?? []).map((s, i) => ({
+        ...s,
+        name: [s.first_name, s.last_name].filter(Boolean).join(' ') || `Profesional ${s.professional_id}`,
+        role: s.role ?? '—',
+        rev: s.revenue ?? 0,
+        appts: s.bookings ?? 0,
+        clients: s.clients_count ?? 0,
+        rating: s.rating ?? '—',
+        utilization: s.utilization ?? 0,
+        color: CHART[i % CHART.length],
+      })),
+    [staffData]
+  );
+
+  const maxRev = staff.length ? Math.max(...staff.map((s) => s.rev)) : 1;
+  const totalRev = staff.reduce((acc, s) => acc + s.rev, 0);
+  const totalAppts = staff.reduce((acc, s) => acc + s.appts, 0);
+  const topStaff = staff[0] ?? null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
       <div className="z-kpi-grid">
         <StatCard
           label="Top empleada"
-          value={topStaff.name.split(' ')[0]}
-          caption={`${D.money(topStaff.rev)} este mes`}
+          value={topStaff?.name.split(' ')[0] ?? '—'}
+          caption={topStaff ? `${money(topStaff.rev)} este mes` : '—'}
           icon="Award"
           numeralStyle="sans"
         />
         <StatCard
           label="Ingresos equipo"
-          value={D.money(totalRev)}
-          delta={5.8}
-          caption="vs mes anterior"
+          value={totalRev ? money(totalRev) : '—'}
+          caption="este mes"
           icon="TrendingUp"
-          spark={D.series(61, 12, 70000, 10000, 500)}
+          spark={[]}
           sparkColor="var(--chart-1)"
         />
-        <StatCard label="Rating promedio" value={`★ ${avgRating}`} delta={0.1} caption="satisfacción" icon="Star" />
+        <StatCard label="Rating promedio" value="—" caption="sin datos" icon="Star" />
         <StatCard
           label="Total citas"
-          value={totalAppts.toLocaleString('es-MX')}
-          delta={8.1}
-          caption="vs mes anterior"
+          value={totalAppts ? totalAppts.toLocaleString('es-MX') : '—'}
+          caption="este mes"
           icon="Calendar"
         />
       </div>
 
       <div className="z-staff-grid">
-        {D.staff.map((s, i) => (
-          <StaffCard key={s.name} s={s} rank={i + 1} maxRev={maxRev} money={D.money} />
+        {staff.map((s, i) => (
+          <StaffCard key={s.name} s={s} rank={i + 1} maxRev={maxRev} money={money} />
         ))}
       </div>
 
@@ -66,14 +94,14 @@ const Staff = () => {
         <Card eyebrow="Distribución" title="Ingresos por empleada">
           <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
             <Donut
-              data={D.staff.map((s) => ({ value: s.rev, color: s.color }))}
+              data={staff.map((s) => ({ value: s.rev, color: s.color }))}
               size={150}
               thickness={20}
-              centerValue={D.moneyK(totalRev)}
+              centerValue={moneyK(totalRev)}
               centerLabel="total"
             />
             <div style={{ flex: 1, minWidth: 120 }}>
-              {D.staff.map((s, i) => (
+              {staff.map((s, i) => (
                 <div
                   key={s.name}
                   style={{
@@ -81,7 +109,7 @@ const Staff = () => {
                     justifyContent: 'space-between',
                     alignItems: 'center',
                     padding: '6px 0',
-                    borderBottom: i < D.staff.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+                    borderBottom: i < staff.length - 1 ? '1px solid var(--border-subtle)' : 'none',
                   }}
                 >
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -100,7 +128,7 @@ const Staff = () => {
                       color: 'var(--text-heading)',
                     }}
                   >
-                    {Math.round((s.rev / totalRev) * 100)}%
+                    {totalRev ? `${Math.round((s.rev / totalRev) * 100)}%` : '—'}
                   </span>
                 </div>
               ))}
@@ -110,7 +138,7 @@ const Staff = () => {
 
         <Card eyebrow="Comparativa" title="Citas por empleada">
           <BarChart
-            data={D.staff.map((s) => ({ label: s.name.split(' ')[0], value: s.appts, color: s.color }))}
+            data={staff.map((s) => ({ label: s.name.split(' ')[0], value: s.appts, color: s.color }))}
             height={200}
             yFormat={(v) => v}
           />
@@ -118,16 +146,16 @@ const Staff = () => {
       </div>
 
       <Card eyebrow="Ranking" title="Por ingresos del mes">
-        {D.staff.map((s, i) => (
+        {staff.map((s, i) => (
           <RankRow
             key={s.name}
             rank={i + 1}
             label={s.name}
-            sublabel={`${s.appts} citas · ${s.clients} clientas`}
-            value={D.money(s.rev)}
+            sublabel={`${s.appts} citas`}
+            value={money(s.rev)}
             ratio={s.rev / maxRev}
             color={s.color}
-            last={i === D.staff.length - 1}
+            last={i === staff.length - 1}
           />
         ))}
       </Card>
@@ -135,7 +163,7 @@ const Staff = () => {
       <Card eyebrow="Detalle" title="Tabla de personal">
         <DataTable
           columns={COLUMNS}
-          rows={D.staff}
+          rows={staff}
           renderCell={(row, key) => {
             if (key === 'name')
               return (
@@ -144,15 +172,15 @@ const Staff = () => {
                   <span style={{ fontWeight: 'var(--fw-medium)', color: 'var(--text-heading)' }}>{row.name}</span>
                 </div>
               );
-            if (key === 'rev') return D.money(row.rev);
-            if (key === 'rating') return `★ ${row.rating}`;
+            if (key === 'rev') return money(row.rev);
+            if (key === 'rating') return row.rating !== '—' ? `★ ${row.rating}` : '—';
             if (key === 'utilization')
               return (
                 <Badge tone={row.utilization > 0.8 ? 'positive' : row.utilization > 0.6 ? 'caution' : 'neutral'}>
-                  {Math.round(row.utilization * 100)}%
+                  {row.utilization ? `${Math.round(row.utilization * 100)}%` : '—'}
                 </Badge>
               );
-            return row[key];
+            return row[key] ?? '—';
           }}
         />
       </Card>


### PR DESCRIPTION
## Summary

- **revenue, services, staff pages** had zero API calls — all data was hardcoded fake numbers. Now wired to `api.kpis()`, `api.revenueByDay()`, `api.topServices()`, `api.staffPerformance()`, and `api.paymentMethodsBreakdown()`.
- **overview, clients pages** had real API calls but fell back to mock data when the API returned nothing. Fallbacks removed; sections now show `—` or "Sin datos" empty states.
- Hardcoded nav badge `8` on Citas removed.
- All `D.series()` fake sparklines replaced with `[]`.
- Fields with no API endpoint yet (category breakdown, loyalty segments, retention rate, best day, monthly goal) show `—` explicitly instead of fabricated numbers.

## Test plan

- [ ] Open each page and confirm no fake numbers appear when the API is unreachable or returns no data
- [ ] Verify Resumen KPI cards load real values when API is up
- [ ] Verify Ingresos area chart renders from `revenue-by-day` endpoint
- [ ] Verify Servicios ranking populates from `top-services` endpoint
- [ ] Verify Personal table populates from `staff-performance` endpoint
- [ ] Confirm Citas nav item no longer shows badge `8`
- [ ] Confirm empty state messages appear gracefully when data is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)