### PR TITLE
Fix Prettier formatting errors from #25

### DIFF
--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -47,13 +47,7 @@ const Clients = () => {
       <div className="z-2col">
         <Card eyebrow="Segmentación" title="Lealtad de clientas">
           <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
-            <Donut
-              data={[]}
-              size={150}
-              thickness={20}
-              centerValue={totalClients || 0}
-              centerLabel="clientes"
-            />
+            <Donut data={[]} size={150} thickness={20} centerValue={totalClients || 0} centerLabel="clientes" />
             <div
               style={{
                 flex: 1,

--- a/src/pages/overview.jsx
+++ b/src/pages/overview.jsx
@@ -40,8 +40,7 @@ const Overview = () => {
   const { data: staffData } = useApi(() => api.staffPerformance(thisMonth), []);
   const { data: recentBookings } = useApi(() => api.bookings({ ...thisMonth, limit: 6 }), []);
 
-  const revDelta =
-    kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
+  const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const apptDelta =
     kpis && kpisPrev?.bookings_count
       ? ((kpis.bookings_count - kpisPrev.bookings_count) / kpisPrev.bookings_count) * 100

--- a/src/pages/revenue.jsx
+++ b/src/pages/revenue.jsx
@@ -47,8 +47,7 @@ const Revenue = () => {
   const { data: revByDay } = useApi(() => api.revenueByDay(thisMonth), []);
   const { data: paymentsData } = useApi(() => api.paymentMethodsBreakdown(thisMonth), []);
 
-  const revDelta =
-    kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
+  const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const ticketDelta =
     kpis && kpisPrev?.avg_ticket ? ((kpis.avg_ticket - kpisPrev.avg_ticket) / kpisPrev.avg_ticket) * 100 : 0;
 
@@ -192,11 +191,7 @@ const Revenue = () => {
                       {Math.round((p.percentage ?? p.pct ?? 0) * 100)}%
                     </span>
                   </div>
-                  <ProgressBar
-                    ratio={p.percentage ?? p.pct ?? 0}
-                    color={`var(--chart-${(i % 5) + 1})`}
-                    height={5}
-                  />
+                  <ProgressBar ratio={p.percentage ?? p.pct ?? 0} color={`var(--chart-${(i % 5) + 1})`} height={5} />
                 </div>
               ))
             ) : (

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -118,9 +118,7 @@ const Services = () => {
           title="Top servicios"
           action={
             <LegendRow
-              items={services
-                .slice(0, 3)
-                .map((s, i) => ({ label: s.name.split(' ')[0], color: CHART[i], line: true }))}
+              items={services.slice(0, 3).map((s, i) => ({ label: s.name.split(' ')[0], color: CHART[i], line: true }))}
             />
           }
         >


### PR DESCRIPTION
## Summary

Hotfix for the CI failure introduced when PR #25 was merged. The build was failing because `CI=true` treats Prettier warnings as errors. This cherry-picks the formatting fix that was pushed after #25 was already merged.

## Files fixed
- `src/pages/clients.jsx`
- `src/pages/overview.jsx`
- `src/pages/revenue.jsx`
- `src/pages/services.jsx`

## Test plan
- [ ] CI build passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)