### PR TITLE
Replace range dropdown with date range picker

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { PanelLeftClose, PanelLeftOpen, Menu, Search, Bell, Plus } from 'lucide-react';
 
 import Sidebar from './components/layout/sidebar';
 import SectionTitle from './components/widgets/section-title';
 import Button from './components/ui/button';
 import IconButton from './components/ui/icon-button';
-import Select from './components/ui/select';
+import DateRangePicker from './components/ui/date-range-picker';
 import { SkeletonCard } from './components/ui/skeleton';
 
 import Overview from './pages/overview';
@@ -36,14 +36,6 @@ const PAGE_META = {
   settings: { eyebrow: 'Configuración', title: 'Ajustes', subtitle: 'Personaliza tu espacio de trabajo' },
 };
 
-const RANGE_OPTIONS = [
-  { value: 'today', label: 'Hoy' },
-  { value: 'week', label: 'Esta semana' },
-  { value: 'month', label: 'Este mes' },
-  { value: 'quarter', label: 'Este trimestre' },
-  { value: 'year', label: 'Este año' },
-];
-
 const HIDE_RANGE = new Set(['settings', 'appointments']);
 
 const PAGE_MAP = {
@@ -55,6 +47,26 @@ const PAGE_MAP = {
   appointments: Appointments,
   settings: SettingsPage,
 };
+
+function initialRange() {
+  const now = new Date();
+  return {
+    from_date: new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10),
+    to_date: now.toISOString().slice(0, 10),
+  };
+}
+
+function computePrevRange(from_date, to_date) {
+  const fromMs = new Date(from_date).getTime();
+  const toMs = new Date(to_date).getTime();
+  const numDays = Math.round((toMs - fromMs) / 86400000) + 1;
+  const prevTo = new Date(fromMs - 86400000);
+  const prevFrom = new Date(prevTo.getTime() - (numDays - 1) * 86400000);
+  return {
+    from_date: prevFrom.toISOString().slice(0, 10),
+    to_date: prevTo.toISOString().slice(0, 10),
+  };
+}
 
 const LoadingScreen = () => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -79,7 +91,12 @@ const App = () => {
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [range, setRange] = useState('month');
+  const [dateRange, setDateRange] = useState(initialRange);
+
+  const prevDateRange = useMemo(
+    () => computePrevRange(dateRange.from_date, dateRange.to_date),
+    [dateRange.from_date, dateRange.to_date]
+  );
 
   const meta = PAGE_META[active] || PAGE_META.overview;
   const PageComponent = PAGE_MAP[active] || Overview;
@@ -151,7 +168,7 @@ const App = () => {
 
             <div className="z-topbar-actions">
               {!HIDE_RANGE.has(active) && (
-                <Select value={range} onChange={setRange} options={RANGE_OPTIONS} size="sm" className="z-hide-sm" />
+                <DateRangePicker value={dateRange} onChange={setDateRange} className="z-hide-sm" />
               )}
               <IconButton icon={Search} variant="ghost" size="md" shape="rounded" title="Buscar" />
               <div style={{ position: 'relative' }}>
@@ -175,7 +192,7 @@ const App = () => {
             </div>
           </div>
 
-          {loading ? <LoadingScreen /> : <PageComponent />}
+          {loading ? <LoadingScreen /> : <PageComponent dateRange={dateRange} prevDateRange={prevDateRange} />}
         </div>
       </main>
     </div>

--- a/src/components/ui/date-range-picker.jsx
+++ b/src/components/ui/date-range-picker.jsx
@@ -1,0 +1,264 @@
+import { useState, useEffect, useRef } from 'react';
+import { CalendarDays, ChevronDown } from 'lucide-react';
+
+const MONTHS_SHORT = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  const [, m, d] = iso.split('-');
+  return `${parseInt(d)} ${MONTHS_SHORT[parseInt(m) - 1]}`;
+}
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+const PRESETS = [
+  {
+    label: 'Hoy',
+    get() {
+      const t = todayIso();
+      return { from_date: t, to_date: t };
+    },
+  },
+  {
+    label: 'Esta semana',
+    get() {
+      const now = new Date();
+      const dow = now.getDay() || 7;
+      const monday = new Date(now);
+      monday.setDate(now.getDate() - dow + 1);
+      return { from_date: monday.toISOString().slice(0, 10), to_date: todayIso() };
+    },
+  },
+  {
+    label: 'Este mes',
+    get() {
+      const now = new Date();
+      return {
+        from_date: new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10),
+        to_date: todayIso(),
+      };
+    },
+  },
+  {
+    label: 'Este trimestre',
+    get() {
+      const now = new Date();
+      const q = Math.floor(now.getMonth() / 3);
+      return {
+        from_date: new Date(now.getFullYear(), q * 3, 1).toISOString().slice(0, 10),
+        to_date: todayIso(),
+      };
+    },
+  },
+  {
+    label: 'Este año',
+    get() {
+      const now = new Date();
+      return {
+        from_date: new Date(now.getFullYear(), 0, 1).toISOString().slice(0, 10),
+        to_date: todayIso(),
+      };
+    },
+  },
+];
+
+const INPUT_STYLE = {
+  display: 'block',
+  marginTop: 4,
+  width: '100%',
+  padding: '5px 8px',
+  borderRadius: 'var(--radius-sm)',
+  border: '1px solid var(--border-default)',
+  background: 'var(--surface-page)',
+  color: 'var(--text-body)',
+  fontFamily: 'var(--font-sans)',
+  fontSize: 'var(--text-sm)',
+  boxSizing: 'border-box',
+};
+
+const DateRangePicker = ({ value, onChange }) => {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [activePreset, setActivePreset] = useState('Este mes');
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const applyPreset = (preset) => {
+    const range = preset.get();
+    setDraft(range);
+    setActivePreset(preset.label);
+    onChange(range);
+    setOpen(false);
+  };
+
+  const applyCustom = () => {
+    if (!draft.from_date || !draft.to_date) return;
+    setActivePreset(null);
+    onChange(draft);
+    setOpen(false);
+  };
+
+  const rangeLabel =
+    value.from_date === value.to_date
+      ? fmtDate(value.from_date)
+      : `${fmtDate(value.from_date)} – ${fmtDate(value.to_date)}`;
+
+  const triggerLabel = activePreset ? `${activePreset} · ${rangeLabel}` : rangeLabel;
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '5px 10px',
+          borderRadius: 'var(--radius-sm)',
+          border: '1px solid var(--border-default)',
+          background: open ? 'var(--surface-page)' : 'var(--surface-card)',
+          color: 'var(--text-body)',
+          fontFamily: 'var(--font-sans)',
+          fontSize: 'var(--text-sm)',
+          cursor: 'pointer',
+          whiteSpace: 'nowrap',
+          transition: 'background var(--dur-fast)',
+        }}
+      >
+        <CalendarDays size={14} strokeWidth={1.7} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+        {triggerLabel}
+        <ChevronDown
+          size={13}
+          strokeWidth={1.7}
+          style={{
+            color: 'var(--text-muted)',
+            marginLeft: 2,
+            transform: open ? 'rotate(180deg)' : 'none',
+            transition: 'transform var(--dur-fast)',
+          }}
+        />
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            right: 0,
+            zIndex: 200,
+            background: 'var(--surface-card)',
+            border: '1px solid var(--border-default)',
+            borderRadius: 'var(--radius-md)',
+            boxShadow: 'var(--shadow-lg)',
+            padding: 14,
+            minWidth: 240,
+          }}
+        >
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 12 }}>
+            {PRESETS.map((p) => {
+              const active = activePreset === p.label;
+              return (
+                <button
+                  key={p.label}
+                  onClick={() => applyPreset(p)}
+                  style={{
+                    padding: '4px 10px',
+                    borderRadius: 'var(--radius-sm)',
+                    border: `1px solid ${active ? 'var(--brand-primary)' : 'var(--border-subtle)'}`,
+                    background: active ? 'var(--brand-primary)' : 'transparent',
+                    color: active ? '#fff' : 'var(--text-body)',
+                    fontFamily: 'var(--font-sans)',
+                    fontSize: 'var(--text-xs)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {p.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div style={{ height: 1, background: 'var(--border-subtle)', marginBottom: 12 }} />
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
+            <label
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-xs)',
+                color: 'var(--text-muted)',
+                display: 'block',
+              }}
+            >
+              Desde
+              <input
+                type="date"
+                value={draft.from_date}
+                max={draft.to_date}
+                onChange={(e) => {
+                  setDraft((d) => ({ ...d, from_date: e.target.value }));
+                  setActivePreset(null);
+                }}
+                style={INPUT_STYLE}
+              />
+            </label>
+            <label
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-xs)',
+                color: 'var(--text-muted)',
+                display: 'block',
+              }}
+            >
+              Hasta
+              <input
+                type="date"
+                value={draft.to_date}
+                min={draft.from_date}
+                max={todayIso()}
+                onChange={(e) => {
+                  setDraft((d) => ({ ...d, to_date: e.target.value }));
+                  setActivePreset(null);
+                }}
+                style={INPUT_STYLE}
+              />
+            </label>
+          </div>
+
+          <button
+            onClick={applyCustom}
+            style={{
+              width: '100%',
+              padding: '6px 0',
+              borderRadius: 'var(--radius-sm)',
+              border: 'none',
+              background: 'var(--brand-primary)',
+              color: '#fff',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 'var(--fw-medium)',
+              cursor: 'pointer',
+            }}
+          >
+            Aplicar
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DateRangePicker;

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -16,9 +16,10 @@ const CLIENT_COLS = [
   { key: 'phone', label: 'Teléfono' },
 ];
 
-const Clients = () => {
+const Clients = ({ dateRange }) => {
   const [search, setSearch] = useState('');
-  const { data: kpis } = useApi(() => api.kpis(), []);
+  const deps = [dateRange.from_date, dateRange.to_date];
+  const { data: kpis } = useApi(() => api.kpis(dateRange), deps);
   const { data: clients, loading } = useApi(() => api.clients({ search: search || undefined, limit: 100 }), [search]);
 
   const totalClients = kpis?.new_clients ?? 0;

--- a/src/pages/overview.jsx
+++ b/src/pages/overview.jsx
@@ -14,31 +14,18 @@ const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
 const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
 
-function thisMonthRange() {
-  const now = new Date();
-  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
-  const to = now.toISOString().slice(0, 10);
-  return { from_date: from, to_date: to };
-}
-
-function prevMonthRange() {
-  const now = new Date();
-  const from = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString().slice(0, 10);
-  const to = new Date(now.getFullYear(), now.getMonth(), 0).toISOString().slice(0, 10);
-  return { from_date: from, to_date: to };
-}
-
-const Overview = () => {
+const Overview = ({ dateRange, prevDateRange }) => {
   const [period, setPeriod] = useState('mes');
-  const thisMonth = thisMonthRange();
-  const prevMonth = prevMonthRange();
 
-  const { data: kpis } = useApi(() => api.kpis(thisMonth), []);
-  const { data: kpisPrev } = useApi(() => api.kpis(prevMonth), []);
-  const { data: revByDay } = useApi(() => api.revenueByDay(thisMonth), []);
-  const { data: topServices } = useApi(() => api.topServices({ ...thisMonth, limit: 5 }), []);
-  const { data: staffData } = useApi(() => api.staffPerformance(thisMonth), []);
-  const { data: recentBookings } = useApi(() => api.bookings({ ...thisMonth, limit: 6 }), []);
+  const deps = [dateRange.from_date, dateRange.to_date];
+  const prevDeps = [prevDateRange.from_date, prevDateRange.to_date];
+
+  const { data: kpis } = useApi(() => api.kpis(dateRange), deps);
+  const { data: kpisPrev } = useApi(() => api.kpis(prevDateRange), prevDeps);
+  const { data: revByDay } = useApi(() => api.revenueByDay(dateRange), deps);
+  const { data: topServices } = useApi(() => api.topServices({ ...dateRange, limit: 5 }), deps);
+  const { data: staffData } = useApi(() => api.staffPerformance(dateRange), deps);
+  const { data: recentBookings } = useApi(() => api.bookings({ ...dateRange, limit: 6 }), deps);
 
   const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const apptDelta =
@@ -58,10 +45,10 @@ const Overview = () => {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
       <div className="z-kpi-grid">
         <StatCard
-          label="Ingresos del mes"
+          label="Ingresos"
           value={kpis ? money(kpis.revenue) : '—'}
           delta={revDelta}
-          caption="vs mes anterior"
+          caption="vs periodo anterior"
           icon="TrendingUp"
           spark={chartData}
           sparkColor="var(--chart-1)"
@@ -70,7 +57,7 @@ const Overview = () => {
           label="Citas completadas"
           value={kpis ? kpis.bookings_count.toLocaleString('es-MX') : '—'}
           delta={apptDelta}
-          caption="vs mes anterior"
+          caption="vs periodo anterior"
           icon="Calendar"
           spark={[]}
           sparkColor="var(--chart-2)"
@@ -79,7 +66,7 @@ const Overview = () => {
           label="Ticket promedio"
           value={kpis ? money(kpis.avg_ticket) : '—'}
           delta={ticketDelta}
-          caption="vs mes anterior"
+          caption="vs periodo anterior"
           icon="DollarSign"
           spark={[]}
           sparkColor="var(--chart-3)"
@@ -97,7 +84,7 @@ const Overview = () => {
       <div className="z-2col-wide">
         <Card
           eyebrow="Ingresos"
-          title="Tendencia del mes"
+          title="Tendencia del periodo"
           action={
             <SegmentedControl
               options={[
@@ -112,7 +99,7 @@ const Overview = () => {
           }
         >
           <LegendRow
-            items={[{ label: 'Este mes', color: 'var(--chart-1)', line: true }]}
+            items={[{ label: 'Periodo seleccionado', color: 'var(--chart-1)', line: true }]}
             style={{ marginBottom: 14 }}
           />
           <AreaChart data={chartData} labels={chartLabels} yFormat={moneyK} height={210} />
@@ -254,7 +241,11 @@ const Overview = () => {
                     {money(s.revenue)}
                   </div>
                   <div
-                    style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}
+                    style={{
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: 'var(--text-xs)',
+                      color: 'var(--text-muted)',
+                    }}
                   >
                     {s.bookings} citas
                   </div>

--- a/src/pages/revenue.jsx
+++ b/src/pages/revenue.jsx
@@ -15,20 +15,6 @@ import DeltaBadge from '../components/ui/delta-badge';
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
 
-function thisMonthRange() {
-  const now = new Date();
-  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
-  const to = now.toISOString().slice(0, 10);
-  return { from_date: from, to_date: to };
-}
-
-function prevMonthRange() {
-  const now = new Date();
-  const from = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString().slice(0, 10);
-  const to = new Date(now.getFullYear(), now.getMonth(), 0).toISOString().slice(0, 10);
-  return { from_date: from, to_date: to };
-}
-
 const COLUMNS = [
   { key: 'label', label: 'Día' },
   { key: 'cur', label: 'Este mes', align: 'right' },
@@ -37,15 +23,16 @@ const COLUMNS = [
   { key: 'appts', label: 'Citas', align: 'right' },
 ];
 
-const Revenue = () => {
+const Revenue = ({ dateRange, prevDateRange }) => {
   const [period, setPeriod] = useState('mes');
-  const thisMonth = thisMonthRange();
-  const prevMonth = prevMonthRange();
 
-  const { data: kpis } = useApi(() => api.kpis(thisMonth), []);
-  const { data: kpisPrev } = useApi(() => api.kpis(prevMonth), []);
-  const { data: revByDay } = useApi(() => api.revenueByDay(thisMonth), []);
-  const { data: paymentsData } = useApi(() => api.paymentMethodsBreakdown(thisMonth), []);
+  const deps = [dateRange.from_date, dateRange.to_date];
+  const prevDeps = [prevDateRange.from_date, prevDateRange.to_date];
+
+  const { data: kpis } = useApi(() => api.kpis(dateRange), deps);
+  const { data: kpisPrev } = useApi(() => api.kpis(prevDateRange), prevDeps);
+  const { data: revByDay } = useApi(() => api.revenueByDay(dateRange), deps);
+  const { data: paymentsData } = useApi(() => api.paymentMethodsBreakdown(dateRange), deps);
 
   const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const ticketDelta =

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -18,13 +18,6 @@ const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Mat
 const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
 const MONTHS = ['E', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
 
-function thisMonthRange() {
-  const now = new Date();
-  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
-  const to = now.toISOString().slice(0, 10);
-  return { from_date: from, to_date: to };
-}
-
 const COLUMNS = [
   { key: 'name', label: 'Servicio' },
   { key: 'cat', label: 'Categoría' },
@@ -36,11 +29,11 @@ const COLUMNS = [
   { key: 'spark', label: 'Últimos 12m', align: 'right' },
 ];
 
-const Services = () => {
+const Services = ({ dateRange }) => {
   const [catFilter, setCatFilter] = useState('Todos');
-  const thisMonth = thisMonthRange();
 
-  const { data: rawTopServices } = useApi(() => api.topServices({ ...thisMonth, limit: 20 }), []);
+  const deps = [dateRange.from_date, dateRange.to_date];
+  const { data: rawTopServices } = useApi(() => api.topServices({ ...dateRange, limit: 20 }), deps);
 
   const services = useMemo(
     () =>

--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -15,13 +15,6 @@ const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
 const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
 
-function thisMonthRange() {
-  const now = new Date();
-  const from = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
-  const to = now.toISOString().slice(0, 10);
-  return { from_date: from, to_date: to };
-}
-
 const COLUMNS = [
   { key: 'name', label: 'Empleada' },
   { key: 'role', label: 'Rol' },
@@ -32,9 +25,9 @@ const COLUMNS = [
   { key: 'utilization', label: 'Utilización', align: 'right' },
 ];
 
-const Staff = () => {
-  const thisMonth = thisMonthRange();
-  const { data: staffData } = useApi(() => api.staffPerformance(thisMonth), []);
+const Staff = ({ dateRange }) => {
+  const deps = [dateRange.from_date, dateRange.to_date];
+  const { data: staffData } = useApi(() => api.staffPerformance(dateRange), deps);
 
   const staff = useMemo(
     () =>


### PR DESCRIPTION
## Summary

- Replaces the static dropdown (Hoy / Esta semana / Este mes…) with a **DateRangePicker** component that supports both quick presets and a custom date range
- Presets: Hoy, Esta semana, Este mes, Este trimestre, Este año — clicking any applies immediately and closes the popover
- Custom range: two native date inputs (Desde / Hasta) with an Apply button; respects min/max constraints so invalid ranges can't be entered
- Trigger button shows the active preset label + formatted date range (e.g. `Este mes · 1 jun – 20 jun`)
- `dateRange` and `prevDateRange` (auto-computed same-duration comparison window) are passed as props to all analytics pages — every view re-fetches when the range changes
- No new dependencies — built with native date inputs and Lucide icons already in the project

## Files changed

| File | Change |
|---|---|
| `src/components/ui/date-range-picker.jsx` | New component |
| `src/App.js` | Swap Select → DateRangePicker; compute + pass `dateRange`/`prevDateRange` |
| `src/pages/overview.jsx` | Accept props, add date deps to useApi |
| `src/pages/revenue.jsx` | Accept props, add date deps to useApi |
| `src/pages/services.jsx` | Accept props, add date deps to useApi |
| `src/pages/staff.jsx` | Accept props, add date deps to useApi |
| `src/pages/clients.jsx` | Accept props, add date deps to kpis useApi |

## Test plan

- [ ] CI build passes
- [ ] Picker opens/closes on click and closes on outside click
- [ ] All 5 presets apply immediately and update the trigger label
- [ ] Custom date inputs enforce min/max; Apply button re-fetches data
- [ ] Switching views preserves the selected range
- [ ] Picker is hidden on Citas and Ajustes pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)