### PR TITLE
feat(settings): make all settings forms editable and wired to API

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,10 +1,22 @@
 const BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8001';
 const API_KEY = process.env.REACT_APP_API_KEY || 'dev-key';
 
+const HEADERS = { 'X-API-Key': API_KEY, 'Content-Type': 'application/json' };
+
 async function get(path, params = {}) {
   const url = new URL(`${BASE_URL}${path}`);
   Object.entries(params).forEach(([k, v]) => v != null && url.searchParams.set(k, v));
-  const res = await fetch(url.toString(), { headers: { 'X-API-Key': API_KEY } });
+  const res = await fetch(url.toString(), { headers: HEADERS });
+  if (!res.ok) throw new Error(`API ${res.status}: ${path}`);
+  return res.json();
+}
+
+async function put(path, body) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'PUT',
+    headers: HEADERS,
+    body: JSON.stringify(body),
+  });
   if (!res.ok) throw new Error(`API ${res.status}: ${path}`);
   return res.json();
 }
@@ -23,4 +35,12 @@ export const api = {
   services: () => get('/services'),
   products: () => get('/products'),
   paymentMethods: () => get('/payment-methods'),
+
+  businessProfile: () => get('/business-profile'),
+  updateBusinessProfile: (data) => put('/business-profile', data),
+  businessHours: () => get('/business-hours'),
+  updateBusinessHours: (data) => put('/business-hours', data),
+  userProfile: () => get('/me'),
+  updateUserProfile: (data) => put('/me', data),
+  changePassword: (data) => put('/me/password', data),
 };

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -42,5 +42,4 @@ export const api = {
   updateBusinessHours: (data) => put('/business-hours', data),
   userProfile: () => get('/me'),
   updateUserProfile: (data) => put('/me', data),
-  changePassword: (data) => put('/me/password', data),
 };

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -47,13 +47,7 @@ const Clients = () => {
       <div className="z-2col">
         <Card eyebrow="Segmentación" title="Lealtad de clientas">
           <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
-            <Donut
-              data={[]}
-              size={150}
-              thickness={20}
-              centerValue={totalClients || 0}
-              centerLabel="clientes"
-            />
+            <Donut data={[]} size={150} thickness={20} centerValue={totalClients || 0} centerLabel="clientes" />
             <div
               style={{
                 flex: 1,

--- a/src/pages/overview.jsx
+++ b/src/pages/overview.jsx
@@ -40,8 +40,7 @@ const Overview = () => {
   const { data: staffData } = useApi(() => api.staffPerformance(thisMonth), []);
   const { data: recentBookings } = useApi(() => api.bookings({ ...thisMonth, limit: 6 }), []);
 
-  const revDelta =
-    kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
+  const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const apptDelta =
     kpis && kpisPrev?.bookings_count
       ? ((kpis.bookings_count - kpisPrev.bookings_count) / kpisPrev.bookings_count) * 100

--- a/src/pages/revenue.jsx
+++ b/src/pages/revenue.jsx
@@ -47,8 +47,7 @@ const Revenue = () => {
   const { data: revByDay } = useApi(() => api.revenueByDay(thisMonth), []);
   const { data: paymentsData } = useApi(() => api.paymentMethodsBreakdown(thisMonth), []);
 
-  const revDelta =
-    kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
+  const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const ticketDelta =
     kpis && kpisPrev?.avg_ticket ? ((kpis.avg_ticket - kpisPrev.avg_ticket) / kpisPrev.avg_ticket) * 100 : 0;
 
@@ -192,11 +191,7 @@ const Revenue = () => {
                       {Math.round((p.percentage ?? p.pct ?? 0) * 100)}%
                     </span>
                   </div>
-                  <ProgressBar
-                    ratio={p.percentage ?? p.pct ?? 0}
-                    color={`var(--chart-${(i % 5) + 1})`}
-                    height={5}
-                  />
+                  <ProgressBar ratio={p.percentage ?? p.pct ?? 0} color={`var(--chart-${(i % 5) + 1})`} height={5} />
                 </div>
               ))
             ) : (

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -118,9 +118,7 @@ const Services = () => {
           title="Top servicios"
           action={
             <LegendRow
-              items={services
-                .slice(0, 3)
-                .map((s, i) => ({ label: s.name.split(' ')[0], color: CHART[i], line: true }))}
+              items={services.slice(0, 3).map((s, i) => ({ label: s.name.split(' ')[0], color: CHART[i], line: true }))}
             />
           }
         >

--- a/src/pages/settings.jsx
+++ b/src/pages/settings.jsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import D from '../mocks/data';
+import { useState, useEffect } from 'react';
+import { api } from '../lib/api';
+import { useApi } from '../hooks/use-api';
 import Card from '../components/ui/card';
 import Button from '../components/ui/button';
 import Avatar from '../components/ui/avatar';
@@ -7,100 +8,245 @@ import Badge from '../components/ui/badge';
 import Select from '../components/ui/select';
 import SegmentedControl from '../components/ui/segmented-control';
 
-const Toggle = ({ checked, onChange, label }) => (
-  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 0' }}>
-    <span style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}>
-      {label}
-    </span>
-    <button
-      onClick={() => onChange(!checked)}
+/* ── helpers ─────────────────────────────────────────────────────────── */
+
+const DAYS = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'];
+
+const DEFAULT_SCHEDULE = DAYS.map((day, i) => ({
+  day,
+  open: i < 6,
+  from: i === 5 ? '10:00' : '09:00',
+  to: i === 5 ? '18:00' : '19:00',
+}));
+
+async function save(setStatus, fn) {
+  setStatus('saving');
+  try {
+    await fn();
+    setStatus('saved');
+    setTimeout(() => setStatus(null), 2500);
+  } catch {
+    setStatus('error');
+  }
+}
+
+/* ── sub-components ───────────────────────────────────────────────────── */
+
+const ToggleSwitch = ({ checked, onChange }) => (
+  <button
+    onClick={() => onChange(!checked)}
+    style={{
+      width: 42,
+      height: 24,
+      borderRadius: 12,
+      background: checked ? 'var(--brand-primary)' : 'var(--ink-200)',
+      border: 'none',
+      cursor: 'pointer',
+      position: 'relative',
+      flexShrink: 0,
+      transition: 'background var(--dur-fast) var(--ease-soft)',
+    }}
+  >
+    <span
       style={{
-        width: 42,
-        height: 24,
-        borderRadius: 12,
-        background: checked ? 'var(--brand-primary)' : 'var(--ink-200)',
-        border: 'none',
-        cursor: 'pointer',
-        position: 'relative',
-        transition: 'background var(--dur-fast) var(--ease-soft)',
-        flexShrink: 0,
+        position: 'absolute',
+        top: 2,
+        left: checked ? 20 : 2,
+        width: 20,
+        height: 20,
+        borderRadius: '50%',
+        background: 'var(--white)',
+        boxShadow: 'var(--shadow-xs)',
+        transition: 'left var(--dur-fast) var(--ease-soft)',
+      }}
+    />
+  </button>
+);
+
+const FieldRow = ({ label, value, onChange, type = 'text', placeholder = '' }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+    <label
+      style={{
+        fontFamily: 'var(--font-sans)',
+        fontSize: 'var(--text-xs)',
+        fontWeight: 'var(--fw-semibold)',
+        color: 'var(--text-secondary)',
+        letterSpacing: '0.02em',
       }}
     >
-      <span
-        style={{
-          position: 'absolute',
-          top: 2,
-          left: checked ? 20 : 2,
-          width: 20,
-          height: 20,
-          borderRadius: '50%',
-          background: 'var(--white)',
-          boxShadow: 'var(--shadow-xs)',
-          transition: 'left var(--dur-fast) var(--ease-soft)',
-        }}
-      />
-    </button>
+      {label}
+    </label>
+    <input
+      type={type}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      style={{
+        height: 38,
+        padding: '0 12px',
+        fontFamily: 'var(--font-sans)',
+        fontSize: 'var(--text-sm)',
+        color: 'var(--text-body)',
+        background: 'var(--surface-card)',
+        border: '1px solid var(--border-default)',
+        borderRadius: 'var(--radius-sm)',
+        outline: 'none',
+      }}
+    />
   </div>
 );
 
-const FieldRow = ({ label, value, type = 'text' }) => {
-  const [val, setVal] = useState(value || '');
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-      <label
-        style={{
-          fontFamily: 'var(--font-sans)',
-          fontSize: 'var(--text-xs)',
-          fontWeight: 'var(--fw-semibold)',
-          color: 'var(--text-secondary)',
-          letterSpacing: '0.02em',
-        }}
-      >
-        {label}
-      </label>
-      <input
-        type={type}
-        value={val}
-        onChange={(e) => setVal(e.target.value)}
-        style={{
-          height: 38,
-          padding: '0 12px',
-          fontFamily: 'var(--font-sans)',
-          fontSize: 'var(--text-sm)',
-          color: 'var(--text-body)',
-          background: 'var(--surface-card)',
-          border: '1px solid var(--border-default)',
-          borderRadius: 'var(--radius-sm)',
-          outline: 'none',
-        }}
-      />
-    </div>
-  );
+const SaveRow = ({ status, label = 'Guardar cambios', onSave }) => (
+  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 12, marginTop: 20 }}>
+    {status === 'saved' && (
+      <span style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--green-600)' }}>
+        ✓ Guardado
+      </span>
+    )}
+    {status === 'error' && (
+      <span style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--red-600)' }}>
+        Error al guardar
+      </span>
+    )}
+    <Button variant="primary" size="md" onClick={onSave} disabled={status === 'saving'}>
+      {status === 'saving' ? 'Guardando…' : label}
+    </Button>
+  </div>
+);
+
+const TIME_INPUT = {
+  height: 34,
+  padding: '0 8px',
+  fontFamily: 'var(--font-sans)',
+  fontSize: 'var(--text-sm)',
+  color: 'var(--text-body)',
+  background: 'var(--surface-card)',
+  border: '1px solid var(--border-default)',
+  borderRadius: 'var(--radius-sm)',
+  width: 94,
 };
+
+/* ── TABS ─────────────────────────────────────────────────────────────── */
 
 const TABS = [
   { value: 'negocio', label: 'Negocio' },
   { value: 'cuenta', label: 'Cuenta' },
-  { value: 'notificaciones', label: 'Notificaciones' },
   { value: 'preferencias', label: 'Preferencias' },
 ];
 
+/* ── main component ───────────────────────────────────────────────────── */
+
 const Settings = () => {
   const [tab, setTab] = useState('negocio');
-  const [notifs, setNotifs] = useState({
-    newAppt: true,
-    cancelAppt: true,
-    payment: true,
-    reminder24: true,
-    reminder2h: false,
-    weekReport: true,
-    monthReport: true,
-    newClient: false,
-    reviews: true,
-  });
+
+  /* spa info */
+  const [spa, setSpa] = useState({ nombre: '', telefono: '', email: '', web: '', direccion: '' });
+  const [spaStatus, setSpaStatus] = useState(null);
+  const { data: spaData } = useApi(() => api.businessProfile(), []);
+
+  useEffect(() => {
+    if (!spaData) return;
+    setSpa({
+      nombre: spaData.nombre ?? spaData.name ?? '',
+      telefono: spaData.telefono ?? spaData.phone ?? '',
+      email: spaData.email ?? '',
+      web: spaData.web ?? spaData.website ?? '',
+      direccion: spaData.direccion ?? spaData.address ?? '',
+    });
+  }, [spaData]);
+
+  const saveSpa = () =>
+    save(setSpaStatus, () =>
+      api.updateBusinessProfile({
+        name: spa.nombre,
+        phone: spa.telefono,
+        email: spa.email,
+        website: spa.web,
+        address: spa.direccion,
+      })
+    );
+
+  /* schedule */
+  const [schedule, setSchedule] = useState(DEFAULT_SCHEDULE);
+  const [scheduleStatus, setScheduleStatus] = useState(null);
+  const { data: hoursData } = useApi(() => api.businessHours(), []);
+
+  useEffect(() => {
+    if (!hoursData) return;
+    setSchedule(
+      DAYS.map((day, i) => {
+        const row = hoursData.find((h) => h.day === day || h.day_name === day);
+        return row
+          ? {
+              day,
+              open: row.open ?? row.is_open ?? true,
+              from: row.from ?? row.open_time ?? '09:00',
+              to: row.to ?? row.close_time ?? '19:00',
+            }
+          : DEFAULT_SCHEDULE[i];
+      })
+    );
+  }, [hoursData]);
+
+  const updateDay = (i, patch) => setSchedule((s) => s.map((r, j) => (j === i ? { ...r, ...patch } : r)));
+
+  const saveSchedule = () => save(setScheduleStatus, () => api.updateBusinessHours(schedule));
+
+  /* staff */
+  const { data: profData } = useApi(() => api.professionals(), []);
+  const staff = profData ?? [];
+
+  /* profile */
+  const [profile, setProfile] = useState({ nombre: '', apellido: '', email: '', telefono: '' });
+  const [profileStatus, setProfileStatus] = useState(null);
+  const { data: profileData } = useApi(() => api.userProfile(), []);
+
+  useEffect(() => {
+    if (!profileData) return;
+    setProfile({
+      nombre: profileData.first_name ?? profileData.nombre ?? '',
+      apellido: profileData.last_name ?? profileData.apellido ?? '',
+      email: profileData.email ?? '',
+      telefono: profileData.phone ?? profileData.telefono ?? '',
+    });
+  }, [profileData]);
+
+  const saveProfile = () =>
+    save(setProfileStatus, () =>
+      api.updateUserProfile({
+        first_name: profile.nombre,
+        last_name: profile.apellido,
+        email: profile.email,
+        phone: profile.telefono,
+      })
+    );
+
+  /* password */
+  const [pwd, setPwd] = useState({ current: '', nuevo: '', confirm: '' });
+  const [pwdStatus, setPwdStatus] = useState(null);
+  const [pwdError, setPwdError] = useState('');
+
+  const savePassword = () => {
+    if (pwd.nuevo !== pwd.confirm) {
+      setPwdError('Las contraseñas no coinciden');
+      return;
+    }
+    if (pwd.nuevo.length < 8) {
+      setPwdError('Mínimo 8 caracteres');
+      return;
+    }
+    setPwdError('');
+    save(setPwdStatus, () => api.changePassword({ current_password: pwd.current, new_password: pwd.nuevo })).then(() =>
+      setPwd({ current: '', nuevo: '', confirm: '' })
+    );
+  };
+
+  /* preferences */
   const [currency, setCurrency] = useState('MXN');
   const [lang, setLang] = useState('es');
   const [theme, setTheme] = useState('light');
+
+  /* ── render ─────────────────────────────────────────────────────────── */
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
@@ -108,103 +254,169 @@ const Settings = () => {
         <SegmentedControl options={TABS} value={tab} onChange={setTab} size="md" />
       </div>
 
+      {/* ── NEGOCIO ─────────────────────────────────────────────────────── */}
       {tab === 'negocio' && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           <Card eyebrow="Negocio" title="Información del spa">
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
-              <FieldRow label="Nombre del negocio" value="Zenya Nails & Spa" />
-              <FieldRow label="Teléfono" value="+52 55 1234 5678" type="tel" />
-              <FieldRow label="Email de contacto" value="hola@zenya.mx" type="email" />
-              <FieldRow label="Sitio web" value="www.zenya.mx" />
+              <FieldRow
+                label="Nombre del negocio"
+                value={spa.nombre}
+                onChange={(v) => setSpa((s) => ({ ...s, nombre: v }))}
+                placeholder="Zenya Nails & Spa"
+              />
+              <FieldRow
+                label="Teléfono"
+                value={spa.telefono}
+                onChange={(v) => setSpa((s) => ({ ...s, telefono: v }))}
+                type="tel"
+                placeholder="+52 55 0000 0000"
+              />
+              <FieldRow
+                label="Email de contacto"
+                value={spa.email}
+                onChange={(v) => setSpa((s) => ({ ...s, email: v }))}
+                type="email"
+                placeholder="hola@zenya.mx"
+              />
+              <FieldRow
+                label="Sitio web"
+                value={spa.web}
+                onChange={(v) => setSpa((s) => ({ ...s, web: v }))}
+                placeholder="www.zenya.mx"
+              />
               <div style={{ gridColumn: '1 / -1' }}>
-                <FieldRow label="Dirección" value="Av. Álvaro Obregón 123, Col. Roma Norte, CDMX" />
+                <FieldRow
+                  label="Dirección"
+                  value={spa.direccion}
+                  onChange={(v) => setSpa((s) => ({ ...s, direccion: v }))}
+                  placeholder="Av. Álvaro Obregón 123, Col. Roma Norte, CDMX"
+                />
               </div>
             </div>
-            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 20 }}>
-              <Button variant="primary" size="md">
-                Guardar cambios
-              </Button>
-            </div>
+            <SaveRow status={spaStatus} onSave={saveSpa} />
           </Card>
 
-          <Card eyebrow="Horario" title="Días y horas de servicio">
+          <Card eyebrow="Horario" title="Días y horario de servicio">
             <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
-              {['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'].map((day, i) => (
+              {schedule.map((row, i) => (
                 <div
-                  key={day}
+                  key={row.day}
                   style={{
                     display: 'flex',
                     alignItems: 'center',
-                    justifyContent: 'space-between',
+                    gap: 12,
                     padding: '10px 0',
                     borderBottom: i < 6 ? '1px solid var(--border-subtle)' : 'none',
                   }}
                 >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                    <span
-                      style={{
-                        fontFamily: 'var(--font-sans)',
-                        fontSize: 'var(--text-sm)',
-                        color: 'var(--text-body)',
-                        width: 80,
-                      }}
-                    >
-                      {day}
-                    </span>
-                    <Badge tone={i < 6 ? 'positive' : 'neutral'} dot={i < 6}>
-                      {i < 6 ? 'Abierto' : 'Cerrado'}
-                    </Badge>
-                  </div>
-                  {i < 6 && (
-                    <span
-                      style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}
-                    >
-                      {i === 5 ? '10:00 – 18:00' : '9:00 – 19:00'}
-                    </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: 'var(--text-sm)',
+                      color: 'var(--text-body)',
+                      width: 88,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {row.day}
+                  </span>
+                  <ToggleSwitch checked={row.open} onChange={(v) => updateDay(i, { open: v })} />
+                  {row.open ? (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <input
+                        type="time"
+                        value={row.from}
+                        onChange={(e) => updateDay(i, { from: e.target.value })}
+                        style={TIME_INPUT}
+                      />
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-sm)',
+                          color: 'var(--text-muted)',
+                        }}
+                      >
+                        —
+                      </span>
+                      <input
+                        type="time"
+                        value={row.to}
+                        onChange={(e) => updateDay(i, { to: e.target.value })}
+                        style={TIME_INPUT}
+                      />
+                    </div>
+                  ) : (
+                    <Badge tone="neutral">Cerrado</Badge>
                   )}
                 </div>
               ))}
             </div>
+            <SaveRow status={scheduleStatus} onSave={saveSchedule} />
           </Card>
 
           <Card eyebrow="Personal" title="Equipo">
-            {D.staff.map((s, i) => (
-              <div
-                key={s.name}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 12,
-                  padding: '10px 0',
-                  borderBottom: i < D.staff.length - 1 ? '1px solid var(--border-subtle)' : 'none',
-                }}
-              >
-                <Avatar name={s.name} size="sm" tone={i === 0 ? 'rose' : i === 1 ? 'lavender' : 'ink'} />
-                <div style={{ flex: 1 }}>
+            {staff.length ? (
+              staff.map((s, i) => {
+                const name =
+                  [s.first_name, s.last_name].filter(Boolean).join(' ') || `Profesional ${s.professional_id}`;
+                return (
                   <div
+                    key={s.professional_id}
                     style={{
-                      fontFamily: 'var(--font-sans)',
-                      fontSize: 'var(--text-sm)',
-                      fontWeight: 'var(--fw-medium)',
-                      color: 'var(--text-heading)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 12,
+                      padding: '10px 0',
+                      borderBottom: i < staff.length - 1 ? '1px solid var(--border-subtle)' : 'none',
                     }}
                   >
-                    {s.name}
+                    <Avatar name={name} size="sm" tone={i === 0 ? 'rose' : i === 1 ? 'lavender' : 'ink'} />
+                    <div style={{ flex: 1 }}>
+                      <div
+                        style={{
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-sm)',
+                          fontWeight: 'var(--fw-medium)',
+                          color: 'var(--text-heading)',
+                        }}
+                      >
+                        {name}
+                      </div>
+                      {s.role && (
+                        <div
+                          style={{
+                            fontFamily: 'var(--font-sans)',
+                            fontSize: 'var(--text-xs)',
+                            color: 'var(--text-muted)',
+                          }}
+                        >
+                          {s.role}
+                        </div>
+                      )}
+                    </div>
+                    <Badge tone="positive" dot>
+                      Activa
+                    </Badge>
+                    <Button variant="ghost" size="sm">
+                      Editar
+                    </Button>
                   </div>
-                  <div
-                    style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}
-                  >
-                    {s.role}
-                  </div>
-                </div>
-                <Badge tone="positive" dot>
-                  Activa
-                </Badge>
-                <Button variant="ghost" size="sm">
-                  Editar
-                </Button>
+                );
+              })
+            ) : (
+              <div
+                style={{
+                  padding: '16px 0',
+                  textAlign: 'center',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                }}
+              >
+                Sin personal registrado
               </div>
-            ))}
+            )}
             <div style={{ marginTop: 16 }}>
               <Button variant="secondary" size="sm">
                 + Agregar empleada
@@ -214,11 +426,17 @@ const Settings = () => {
         </div>
       )}
 
+      {/* ── CUENTA ──────────────────────────────────────────────────────── */}
       {tab === 'cuenta' && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           <Card eyebrow="Perfil" title="Mi cuenta">
             <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 20 }}>
-              <Avatar name="Valentina López" size="lg" tone="rose" ring />
+              <Avatar
+                name={[profile.nombre, profile.apellido].filter(Boolean).join(' ') || 'Usuario'}
+                size="lg"
+                tone="rose"
+                ring
+              />
               <div>
                 <div
                   style={{
@@ -227,141 +445,78 @@ const Settings = () => {
                     color: 'var(--text-heading)',
                   }}
                 >
-                  Valentina López
+                  {[profile.nombre, profile.apellido].filter(Boolean).join(' ') || '—'}
                 </div>
                 <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
                   Propietaria · Zenya Nails &amp; Spa
                 </div>
-                <Badge tone="rose" style={{ marginTop: 6 }}>
-                  Dueña
-                </Badge>
               </div>
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
-              <FieldRow label="Nombre" value="Valentina" />
-              <FieldRow label="Apellido" value="López" />
-              <FieldRow label="Email" value="valentina@zenya.mx" type="email" />
-              <FieldRow label="Teléfono" value="+52 55 9876 5432" type="tel" />
+              <FieldRow
+                label="Nombre"
+                value={profile.nombre}
+                onChange={(v) => setProfile((p) => ({ ...p, nombre: v }))}
+              />
+              <FieldRow
+                label="Apellido"
+                value={profile.apellido}
+                onChange={(v) => setProfile((p) => ({ ...p, apellido: v }))}
+              />
+              <FieldRow
+                label="Email"
+                value={profile.email}
+                onChange={(v) => setProfile((p) => ({ ...p, email: v }))}
+                type="email"
+              />
+              <FieldRow
+                label="Teléfono"
+                value={profile.telefono}
+                onChange={(v) => setProfile((p) => ({ ...p, telefono: v }))}
+                type="tel"
+              />
             </div>
-            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 20 }}>
-              <Button variant="primary" size="md">
-                Guardar cambios
-              </Button>
-            </div>
+            <SaveRow status={profileStatus} onSave={saveProfile} />
           </Card>
 
           <Card eyebrow="Seguridad" title="Contraseña y acceso">
             <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-              <FieldRow label="Contraseña actual" value="" type="password" />
-              <FieldRow label="Nueva contraseña" value="" type="password" />
-              <FieldRow label="Confirmar contraseña" value="" type="password" />
-              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <Button variant="primary" size="md">
-                  Cambiar contraseña
-                </Button>
-              </div>
+              <FieldRow
+                label="Contraseña actual"
+                value={pwd.current}
+                onChange={(v) => setPwd((p) => ({ ...p, current: v }))}
+                type="password"
+              />
+              <FieldRow
+                label="Nueva contraseña"
+                value={pwd.nuevo}
+                onChange={(v) => setPwd((p) => ({ ...p, nuevo: v }))}
+                type="password"
+              />
+              <FieldRow
+                label="Confirmar nueva contraseña"
+                value={pwd.confirm}
+                onChange={(v) => setPwd((p) => ({ ...p, confirm: v }))}
+                type="password"
+              />
+              {pwdError && (
+                <span
+                  style={{
+                    fontFamily: 'var(--font-sans)',
+                    fontSize: 'var(--text-sm)',
+                    color: 'var(--red-600)',
+                  }}
+                >
+                  {pwdError}
+                </span>
+              )}
+              <SaveRow status={pwdStatus} label="Cambiar contraseña" onSave={savePassword} />
             </div>
           </Card>
         </div>
       )}
 
-      {tab === 'notificaciones' && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          <Card eyebrow="Citas" title="Notificaciones de citas">
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                borderTop: '1px solid var(--border-subtle)',
-                paddingTop: 8,
-              }}
-            >
-              <Toggle
-                label="Nueva cita confirmada"
-                checked={notifs.newAppt}
-                onChange={(v) => setNotifs({ ...notifs, newAppt: v })}
-              />
-              <div style={{ borderTop: '1px solid var(--border-subtle)' }}>
-                <Toggle
-                  label="Cita cancelada"
-                  checked={notifs.cancelAppt}
-                  onChange={(v) => setNotifs({ ...notifs, cancelAppt: v })}
-                />
-              </div>
-              <div style={{ borderTop: '1px solid var(--border-subtle)' }}>
-                <Toggle
-                  label="Recordatorio 24 horas antes"
-                  checked={notifs.reminder24}
-                  onChange={(v) => setNotifs({ ...notifs, reminder24: v })}
-                />
-              </div>
-              <div style={{ borderTop: '1px solid var(--border-subtle)' }}>
-                <Toggle
-                  label="Recordatorio 2 horas antes"
-                  checked={notifs.reminder2h}
-                  onChange={(v) => setNotifs({ ...notifs, reminder2h: v })}
-                />
-              </div>
-            </div>
-          </Card>
-
-          <Card eyebrow="Pagos" title="Notificaciones de pagos">
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                borderTop: '1px solid var(--border-subtle)',
-                paddingTop: 8,
-              }}
-            >
-              <Toggle
-                label="Pago recibido"
-                checked={notifs.payment}
-                onChange={(v) => setNotifs({ ...notifs, payment: v })}
-              />
-            </div>
-          </Card>
-
-          <Card eyebrow="Reportes" title="Notificaciones de reportes">
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                borderTop: '1px solid var(--border-subtle)',
-                paddingTop: 8,
-              }}
-            >
-              <Toggle
-                label="Reporte semanal"
-                checked={notifs.weekReport}
-                onChange={(v) => setNotifs({ ...notifs, weekReport: v })}
-              />
-              <div style={{ borderTop: '1px solid var(--border-subtle)' }}>
-                <Toggle
-                  label="Reporte mensual"
-                  checked={notifs.monthReport}
-                  onChange={(v) => setNotifs({ ...notifs, monthReport: v })}
-                />
-              </div>
-              <div style={{ borderTop: '1px solid var(--border-subtle)' }}>
-                <Toggle
-                  label="Nueva clienta registrada"
-                  checked={notifs.newClient}
-                  onChange={(v) => setNotifs({ ...notifs, newClient: v })}
-                />
-              </div>
-              <div style={{ borderTop: '1px solid var(--border-subtle)' }}>
-                <Toggle
-                  label="Reseñas y calificaciones"
-                  checked={notifs.reviews}
-                  onChange={(v) => setNotifs({ ...notifs, reviews: v })}
-                />
-              </div>
-            </div>
-          </Card>
-        </div>
-      )}
-
+      {/* ── PREFERENCIAS ────────────────────────────────────────────────── */}
       {tab === 'preferencias' && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           <Card eyebrow="Apariencia" title="Tema y visualización">
@@ -411,47 +566,6 @@ const Settings = () => {
                   { value: 'USD', label: 'USD – Dólar' },
                 ]}
               />
-            </div>
-          </Card>
-
-          <Card eyebrow="Plan" title="Mi plan actual">
-            <div
-              style={{
-                background: 'var(--lavender-50)',
-                borderRadius: 'var(--radius-md)',
-                padding: '20px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: 16,
-                flexWrap: 'wrap',
-              }}
-            >
-              <div>
-                <div
-                  style={{
-                    fontFamily: 'var(--font-display)',
-                    fontSize: 'var(--text-xl)',
-                    color: 'var(--lavender-700)',
-                    marginBottom: 4,
-                  }}
-                >
-                  Plan Básico
-                </div>
-                <div
-                  style={{
-                    fontFamily: 'var(--font-sans)',
-                    fontSize: 'var(--text-sm)',
-                    color: 'var(--lavender-700)',
-                    opacity: 0.8,
-                  }}
-                >
-                  Hasta 2 empleadas · 100 citas/mes · Reportes básicos
-                </div>
-              </div>
-              <Button variant="primary" size="md" style={{ background: 'var(--lavender-700)', color: 'var(--white)' }}>
-                Mejorar a Studio
-              </Button>
             </div>
           </Card>
         </div>

--- a/src/pages/settings.jsx
+++ b/src/pages/settings.jsx
@@ -10,13 +10,23 @@ import SegmentedControl from '../components/ui/segmented-control';
 
 /* ── helpers ─────────────────────────────────────────────────────────── */
 
-const DAYS = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'];
+// day_id: 0=Sunday … 6=Saturday (same as DB and AgendaPro)
+const DAYS = [
+  { name: 'Lunes', day_id: 1 },
+  { name: 'Martes', day_id: 2 },
+  { name: 'Miércoles', day_id: 3 },
+  { name: 'Jueves', day_id: 4 },
+  { name: 'Viernes', day_id: 5 },
+  { name: 'Sábado', day_id: 6 },
+  { name: 'Domingo', day_id: 0 },
+];
 
-const DEFAULT_SCHEDULE = DAYS.map((day, i) => ({
-  day,
-  open: i < 6,
-  from: i === 5 ? '10:00' : '09:00',
-  to: i === 5 ? '18:00' : '19:00',
+const DEFAULT_SCHEDULE = DAYS.map(({ name, day_id }) => ({
+  day: name,
+  day_id,
+  open: day_id !== 0,
+  from: day_id === 6 ? '10:00' : '09:00',
+  to: day_id === 6 ? '18:00' : '19:00',
 }));
 
 async function save(setStatus, fn) {
@@ -147,11 +157,11 @@ const Settings = () => {
   useEffect(() => {
     if (!spaData) return;
     setSpa({
-      nombre: spaData.nombre ?? spaData.name ?? '',
-      telefono: spaData.telefono ?? spaData.phone ?? '',
+      nombre: spaData.name ?? '',
+      telefono: spaData.phone ?? '',
       email: spaData.email ?? '',
-      web: spaData.web ?? spaData.website ?? '',
-      direccion: spaData.direccion ?? spaData.address ?? '',
+      web: spaData.website ?? '',
+      direccion: spaData.address ?? '',
     });
   }, [spaData]);
 
@@ -166,37 +176,48 @@ const Settings = () => {
       })
     );
 
-  /* schedule */
+  /* schedule — maps API day_id → row */
   const [schedule, setSchedule] = useState(DEFAULT_SCHEDULE);
   const [scheduleStatus, setScheduleStatus] = useState(null);
   const { data: hoursData } = useApi(() => api.businessHours(), []);
 
   useEffect(() => {
-    if (!hoursData) return;
+    if (!hoursData || !hoursData.length) return;
+    const byDayId = Object.fromEntries(hoursData.map((h) => [h.day_id, h]));
     setSchedule(
-      DAYS.map((day, i) => {
-        const row = hoursData.find((h) => h.day === day || h.day_name === day);
-        return row
-          ? {
-              day,
-              open: row.open ?? row.is_open ?? true,
-              from: row.from ?? row.open_time ?? '09:00',
-              to: row.to ?? row.close_time ?? '19:00',
-            }
-          : DEFAULT_SCHEDULE[i];
+      DEFAULT_SCHEDULE.map((row) => {
+        const h = byDayId[row.day_id];
+        if (!h) return row;
+        return {
+          ...row,
+          open: h.is_open,
+          from: h.open_time ? String(h.open_time).slice(0, 5) : row.from,
+          to: h.close_time ? String(h.close_time).slice(0, 5) : row.to,
+        };
       })
     );
   }, [hoursData]);
 
   const updateDay = (i, patch) => setSchedule((s) => s.map((r, j) => (j === i ? { ...r, ...patch } : r)));
 
-  const saveSchedule = () => save(setScheduleStatus, () => api.updateBusinessHours(schedule));
+  const saveSchedule = () =>
+    save(setScheduleStatus, () =>
+      api.updateBusinessHours(
+        schedule.map((row) => ({
+          day_id: row.day_id,
+          day_name: row.day,
+          is_open: row.open,
+          open_time: row.open ? row.from : null,
+          close_time: row.open ? row.to : null,
+        }))
+      )
+    );
 
   /* staff */
   const { data: profData } = useApi(() => api.professionals(), []);
   const staff = profData ?? [];
 
-  /* profile */
+  /* profile (owner — stored in business_profile.owner_* fields) */
   const [profile, setProfile] = useState({ nombre: '', apellido: '', email: '', telefono: '' });
   const [profileStatus, setProfileStatus] = useState(null);
   const { data: profileData } = useApi(() => api.userProfile(), []);
@@ -204,10 +225,10 @@ const Settings = () => {
   useEffect(() => {
     if (!profileData) return;
     setProfile({
-      nombre: profileData.first_name ?? profileData.nombre ?? '',
-      apellido: profileData.last_name ?? profileData.apellido ?? '',
+      nombre: profileData.first_name ?? '',
+      apellido: profileData.last_name ?? '',
       email: profileData.email ?? '',
-      telefono: profileData.phone ?? profileData.telefono ?? '',
+      telefono: profileData.phone ?? '',
     });
   }, [profileData]);
 
@@ -220,26 +241,6 @@ const Settings = () => {
         phone: profile.telefono,
       })
     );
-
-  /* password */
-  const [pwd, setPwd] = useState({ current: '', nuevo: '', confirm: '' });
-  const [pwdStatus, setPwdStatus] = useState(null);
-  const [pwdError, setPwdError] = useState('');
-
-  const savePassword = () => {
-    if (pwd.nuevo !== pwd.confirm) {
-      setPwdError('Las contraseñas no coinciden');
-      return;
-    }
-    if (pwd.nuevo.length < 8) {
-      setPwdError('Mínimo 8 caracteres');
-      return;
-    }
-    setPwdError('');
-    save(setPwdStatus, () => api.changePassword({ current_password: pwd.current, new_password: pwd.nuevo })).then(() =>
-      setPwd({ current: '', nuevo: '', confirm: '' })
-    );
-  };
 
   /* preferences */
   const [currency, setCurrency] = useState('MXN');
@@ -477,41 +478,6 @@ const Settings = () => {
               />
             </div>
             <SaveRow status={profileStatus} onSave={saveProfile} />
-          </Card>
-
-          <Card eyebrow="Seguridad" title="Contraseña y acceso">
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-              <FieldRow
-                label="Contraseña actual"
-                value={pwd.current}
-                onChange={(v) => setPwd((p) => ({ ...p, current: v }))}
-                type="password"
-              />
-              <FieldRow
-                label="Nueva contraseña"
-                value={pwd.nuevo}
-                onChange={(v) => setPwd((p) => ({ ...p, nuevo: v }))}
-                type="password"
-              />
-              <FieldRow
-                label="Confirmar nueva contraseña"
-                value={pwd.confirm}
-                onChange={(v) => setPwd((p) => ({ ...p, confirm: v }))}
-                type="password"
-              />
-              {pwdError && (
-                <span
-                  style={{
-                    fontFamily: 'var(--font-sans)',
-                    fontSize: 'var(--text-sm)',
-                    color: 'var(--red-600)',
-                  }}
-                >
-                  {pwdError}
-                </span>
-              )}
-              <SaveRow status={pwdStatus} label="Cambiar contraseña" onSave={savePassword} />
-            </div>
           </Card>
         </div>
       )}


### PR DESCRIPTION
## Summary

- **Información del spa**: all fields now controlled state; *Guardar cambios* calls `PUT /business-profile` with inline ✓ Guardado / Error feedback; fields pre-populate from `GET /business-profile`
- **Días y horario de servicio**: per-day open/close toggle + time inputs; saves via `PUT /business-hours`; pre-populates from `GET /business-hours` on load
- **Mi cuenta**: loads from `GET /me` (owner fields in `business_profile`), saves via `PUT /me`
- **Equipo**: replaced hardcoded mock data with real `api.professionals()` call
- **Removed**: Notificaciones tab, Plan card from Preferencias, Contraseña y acceso card (requires auth system not yet built)
- **`api.js`**: added `put()` helper and 5 new endpoints (`businessProfile`, `updateBusinessProfile`, `businessHours`, `updateBusinessHours`, `userProfile`, `updateUserProfile`)

## Depends on (must be merged/deployed first)

- `mysql-schema-migrations` PR #3 — creates `business_profile` and `business_hours` tables
- `zenya-api` PR #4 — adds `GET/PUT /business-profile`, `GET/PUT /business-hours`, `GET/PUT /me`

## Test plan

- [ ] Ajustes → Negocio → Información del spa: edit any field, click *Guardar cambios* → ✓ Guardado
- [ ] Reload page → fields show the saved values
- [ ] Ajustes → Negocio → Horario: toggle a day closed, change a time, click *Guardar cambios* → ✓ Guardado
- [ ] Reload → schedule reflects saved state
- [ ] Ajustes → Cuenta → Mi cuenta: edit name, save, reload → persists
- [ ] Notificaciones tab is gone
- [ ] Plan card is gone from Preferencias
- [ ] Contraseña y acceso card is gone
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)