### PR TITLE
fix(services): remove empty columns and broken chart

### DIFF
--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -1,64 +1,45 @@
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { api } from '../lib/api';
 import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
 import Card from '../components/ui/card';
 import RankRow from '../components/widgets/rank-row';
 import BarChart from '../components/charts/bar-chart';
-import MultiLine from '../components/charts/multi-line';
 import DataTable from '../components/widgets/data-table';
-import Badge from '../components/ui/badge';
-import Sparkline from '../components/charts/sparkline';
-import DeltaBadge from '../components/ui/delta-badge';
-import LegendRow from '../components/ui/legend-row';
-import SegmentedControl from '../components/ui/segmented-control';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
 const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
-const MONTHS = ['E', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
 
 const COLUMNS = [
   { key: 'name', label: 'Servicio' },
-  { key: 'cat', label: 'Categoría' },
-  { key: 'provider', label: 'Proveedor' },
   { key: 'count', label: 'Citas', align: 'right' },
-  { key: 'avg', label: 'Ticket', align: 'right' },
+  { key: 'avg', label: 'Ticket prom.', align: 'right' },
   { key: 'rev', label: 'Ingresos', align: 'right' },
-  { key: 'trend', label: 'Tendencia', align: 'right' },
-  { key: 'spark', label: 'Últimos 12m', align: 'right' },
 ];
 
 const Services = ({ dateRange }) => {
-  const [catFilter, setCatFilter] = useState('Todos');
-
   const deps = [dateRange.from_date, dateRange.to_date];
   const { data: rawTopServices } = useApi(() => api.topServices({ ...dateRange, limit: 20 }), deps);
 
   const services = useMemo(
     () =>
       (rawTopServices ?? []).map((s) => ({
-        name: s.name ?? s.service_name ?? '—',
-        cat: s.category ?? '—',
-        provider: s.provider ?? '—',
+        name: s.name ?? '—',
         rev: s.revenue ?? 0,
-        count: s.count ?? s.bookings_count ?? 0,
+        count: s.count ?? 0,
         avg: s.count ? Math.round((s.revenue ?? 0) / s.count) : 0,
-        trend: s.trend ?? 0,
-        spark: [],
       })),
     [rawTopServices]
   );
 
   const maxRev = services.length ? Math.max(...services.map((s) => s.rev)) : 1;
   const maxCount = services.length ? Math.max(...services.map((s) => s.count)) : 1;
-  const cats = ['Todos', ...Array.from(new Set(services.map((s) => s.cat).filter((c) => c !== '—')))];
-  const filtered = catFilter === 'Todos' ? services : services.filter((s) => s.cat === catFilter);
+  const totalCitas = services.reduce((sum, s) => sum + s.count, 0);
 
   const topRev = services.length ? services.reduce((a, b) => (a.rev > b.rev ? a : b)) : null;
   const topCount = services.length ? services.reduce((a, b) => (a.count > b.count ? a : b)) : null;
   const topAvg = services.length ? services.reduce((a, b) => (a.avg > b.avg ? a : b)) : null;
-  const topTrend = services.length ? services.reduce((a, b) => (a.trend > b.trend ? a : b)) : null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
@@ -66,7 +47,6 @@ const Services = ({ dateRange }) => {
         <StatCard
           label="Servicio top"
           value={topRev?.name ?? '—'}
-          delta={topRev?.trend ?? 0}
           caption={topRev ? money(topRev.rev) : '—'}
           icon="Sparkles"
           numeralStyle="sans"
@@ -80,15 +60,13 @@ const Services = ({ dateRange }) => {
         <StatCard
           label="Mayor ticket"
           value={topAvg ? money(topAvg.avg) : '—'}
-          delta={topAvg?.trend ?? 0}
           caption={topAvg?.name ?? '—'}
           icon="DollarSign"
         />
         <StatCard
-          label="Mayor crecimiento"
-          value={topTrend ? `+${topTrend.trend}%` : '—'}
-          delta={topTrend?.trend ?? 0}
-          caption={topTrend?.name ?? '—'}
+          label="Total citas"
+          value={totalCitas ? totalCitas.toLocaleString('es-MX') : '—'}
+          caption="en el periodo"
           icon="TrendingUp"
         />
       </div>
@@ -106,20 +84,15 @@ const Services = ({ dateRange }) => {
           />
         </Card>
 
-        <Card
-          eyebrow="Evolución"
-          title="Top servicios"
-          action={
-            <LegendRow
-              items={services.slice(0, 3).map((s, i) => ({ label: s.name.split(' ')[0], color: CHART[i], line: true }))}
-            />
-          }
-        >
-          <MultiLine
-            series={services.slice(0, 3).map((s, i) => ({ data: s.spark, color: CHART[i] }))}
-            labels={MONTHS}
+        <Card eyebrow="Demanda" title="Citas por servicio">
+          <BarChart
+            data={services.map((s, i) => ({
+              label: s.name.split(' ')[0],
+              value: s.count,
+              color: CHART[i % CHART.length],
+            }))}
             height={220}
-            yFormat={moneyK}
+            yFormat={(v) => String(Math.round(v))}
           />
         </Card>
       </div>
@@ -131,7 +104,6 @@ const Services = ({ dateRange }) => {
               key={s.name}
               rank={i + 1}
               label={s.name}
-              sublabel={s.cat}
               value={money(s.rev)}
               ratio={s.rev / maxRev}
               color={CHART[i % CHART.length]}
@@ -148,8 +120,8 @@ const Services = ({ dateRange }) => {
                 key={s.name}
                 rank={i + 1}
                 label={s.name}
-                sublabel={`${s.count} citas · ${money(s.avg)} avg`}
-                value={`${s.count}`}
+                sublabel={`${money(s.avg)} ticket prom.`}
+                value={`${s.count} citas`}
                 ratio={s.count / maxCount}
                 color={CHART[i % CHART.length]}
                 last={i === services.length - 1}
@@ -158,27 +130,13 @@ const Services = ({ dateRange }) => {
         </Card>
       </div>
 
-      <Card
-        eyebrow="Catálogo"
-        title="Todos los servicios"
-        action={
-          <SegmentedControl
-            options={cats.map((c) => ({ value: c, label: c }))}
-            value={catFilter}
-            onChange={setCatFilter}
-            size="sm"
-          />
-        }
-      >
+      <Card eyebrow="Catálogo" title="Todos los servicios">
         <DataTable
           columns={COLUMNS}
-          rows={filtered}
+          rows={services}
           renderCell={(row, key) => {
             if (key === 'rev') return money(row.rev);
             if (key === 'avg') return money(row.avg);
-            if (key === 'cat') return <Badge tone="lavender">{row.cat}</Badge>;
-            if (key === 'trend') return <DeltaBadge value={row.trend} format="percent" size="sm" />;
-            if (key === 'spark') return <Sparkline data={row.spark} width={72} height={24} color="var(--chart-1)" />;
             return row[key];
           }}
         />


### PR DESCRIPTION
## Summary

Three dead columns and a broken chart removed, replaced with real data:

| Problem | Root cause | Fix |
|---|---|---|
| Categoría shows `—` | No `category` column in DB services table | Column removed |
| Proveedor shows `—` | No `provider` column in DB | Column removed |
| Últimos 12m empty | `spark` was hardcoded `[]`, no monthly endpoint | Column + MultiLine removed |
| Tendencia always `0` | No trend field in API response | Column removed |
| "Mayor crecimiento" KPI shows `—` | Based on trend (always 0) | Replaced with **Total citas** |
| "Top servicios" evolution chart empty | Same `spark: []` issue | Replaced with **Citas por servicio** BarChart |

Table now shows only: **Servicio / Citas / Ticket prom. / Ingresos** — all real data from `GET /analytics/top-services`.

## Test plan

- [ ] Servicios tab — all 4 KPI cards show real values
- [ ] "Por servicio" and "Citas por servicio" bar charts both render with data
- [ ] "Por ingresos" and "Por cantidad" ranking cards show services
- [ ] "Todos los servicios" table shows rows with no empty columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)