### PR TITLE
fix(personal): map appts to services_count, fix empty stats and chart

### DIFF
--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -36,8 +36,8 @@ const Staff = ({ dateRange }) => {
         name: [s.first_name, s.last_name].filter(Boolean).join(' ') || `Profesional ${s.professional_id}`,
         role: s.role ?? '—',
         rev: s.revenue ?? 0,
-        appts: s.bookings ?? 0,
-        clients: s.clients_count ?? 0,
+        appts: s.services_count ?? 0,
+        clients: s.clients_count ?? null,
         rating: s.rating ?? '—',
         utilization: s.utilization ?? 0,
         color: CHART[i % CHART.length],
@@ -49,6 +49,11 @@ const Staff = ({ dateRange }) => {
   const totalRev = staff.reduce((acc, s) => acc + s.rev, 0);
   const totalAppts = staff.reduce((acc, s) => acc + s.appts, 0);
   const topStaff = staff[0] ?? null;
+
+  const ratedStaff = staff.filter((s) => s.rating !== '—' && !isNaN(Number(s.rating)));
+  const avgRating = ratedStaff.length
+    ? (ratedStaff.reduce((acc, s) => acc + Number(s.rating), 0) / ratedStaff.length).toFixed(1)
+    : null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
@@ -68,7 +73,12 @@ const Staff = ({ dateRange }) => {
           spark={[]}
           sparkColor="var(--chart-1)"
         />
-        <StatCard label="Rating promedio" value="—" caption="sin datos" icon="Star" />
+        <StatCard
+          label="Rating promedio"
+          value={avgRating ? `★ ${avgRating}` : '—'}
+          caption={avgRating ? 'promedio del equipo' : 'sin datos'}
+          icon="Star"
+        />
         <StatCard
           label="Total citas"
           value={totalAppts ? totalAppts.toLocaleString('es-MX') : '—'}


### PR DESCRIPTION
## Summary

- **Root cause**: `appts` was mapped from `s.bookings` but the API returns `services_count` — this field was always `undefined`, making Total Citas show `—` and the Citas bar chart render empty bars
- **Fix**: Changed mapping to `s.services_count ?? 0`
- **Rating promedio**: Was hardcoded `—`. Now computed dynamically from staff data (still shows `—` since the API doesn't return ratings yet, but will auto-populate once the backend adds the field)
- **Clientas column**: Changed default from `0` to `null` so the table correctly renders `—` instead of a misleading `0`

## Fields not in API (intentional `—`)
`rol`, `rating`, `utilización`, and `clientas` are not returned by `/analytics/staff-performance`. These columns will remain `—` until the backend surfaces those fields.

## Test plan
- [ ] Personal tab → **Total citas** shows a real number (e.g. 110)
- [ ] Personal tab → **Citas por empleada** bar chart shows bars proportional to each employee's service count
- [ ] Personal tab → **Tabla de personal – Citas column** shows per-employee counts (not 0)
- [ ] Personal tab → **Rating promedio** shows `—` / "sin datos" (no regression, just now dynamic)
- [ ] Personal tab → **Clientas column** shows `—` (not 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)