### PR TITLE
fix(staff): remove empty fields, wire up clients_count

### DIFF
--- a/src/components/widgets/staff-card.jsx
+++ b/src/components/widgets/staff-card.jsx
@@ -1,140 +1,101 @@
 import Avatar from '../ui/avatar';
-import ProgressRing from '../charts/progress-ring';
 import Badge from '../ui/badge';
 
-const StaffCard = ({ s, rank, money, style }) => {
-  const utilPct = Math.round(s.utilization * 100);
-
-  return (
-    <div
-      style={{
-        background: 'var(--surface-card)',
-        borderRadius: 'var(--radius-lg)',
-        border: '1px solid var(--border-subtle)',
-        boxShadow: 'var(--shadow-sm)',
-        padding: 20,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 16,
-        ...style,
-      }}
-    >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-        <Avatar name={s.name} size="md" tone={rank === 1 ? 'rose' : rank === 2 ? 'lavender' : 'ink'} />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              fontFamily: 'var(--font-sans)',
-              fontSize: 'var(--text-sm)',
-              fontWeight: 'var(--fw-semibold)',
-              color: 'var(--text-heading)',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {s.name}
-          </div>
-          <div
-            style={{
-              fontFamily: 'var(--font-sans)',
-              fontSize: 'var(--text-xs)',
-              color: 'var(--text-muted)',
-              marginTop: 2,
-            }}
-          >
-            {s.role}
-          </div>
+const StaffCard = ({ s, rank, money }) => (
+  <div
+    style={{
+      background: 'var(--surface-card)',
+      borderRadius: 'var(--radius-lg)',
+      border: '1px solid var(--border-subtle)',
+      boxShadow: 'var(--shadow-sm)',
+      padding: 20,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 16,
+    }}
+  >
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <Avatar name={s.name} size="md" tone={rank === 1 ? 'rose' : rank === 2 ? 'lavender' : 'ink'} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-sans)',
+            fontSize: 'var(--text-sm)',
+            fontWeight: 'var(--fw-semibold)',
+            color: 'var(--text-heading)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {s.name}
         </div>
-        <Badge tone={rank === 1 ? 'rose' : 'neutral'} solid={rank === 1}>
-          #{rank}
-        </Badge>
+        <div
+          style={{
+            fontFamily: 'var(--font-sans)',
+            fontSize: 'var(--text-xs)',
+            color: 'var(--text-muted)',
+            marginTop: 2,
+          }}
+        >
+          {s.clients} clientas · {s.appts} citas
+        </div>
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
-        <div style={{ display: 'flex', gap: 16 }}>
-          <div style={{ textAlign: 'center' }}>
-            <div
-              style={{
-                fontFamily: 'var(--font-display)',
-                fontSize: 'var(--text-xl)',
-                fontWeight: 'var(--fw-medium)',
-                color: 'var(--text-heading)',
-                lineHeight: 1,
-              }}
-            >
-              {money(s.rev)}
-            </div>
-            <div
-              style={{
-                fontFamily: 'var(--font-sans)',
-                fontSize: 'var(--text-2xs)',
-                color: 'var(--text-muted)',
-                marginTop: 3,
-              }}
-            >
-              Ingresos
-            </div>
-          </div>
-          <div style={{ width: 1, background: 'var(--border-subtle)' }} />
-          <div style={{ textAlign: 'center' }}>
-            <div
-              style={{
-                fontFamily: 'var(--font-sans)',
-                fontSize: 'var(--text-lg)',
-                fontWeight: 'var(--fw-bold)',
-                color: 'var(--text-heading)',
-                lineHeight: 1,
-              }}
-            >
-              {s.appts}
-            </div>
-            <div
-              style={{
-                fontFamily: 'var(--font-sans)',
-                fontSize: 'var(--text-2xs)',
-                color: 'var(--text-muted)',
-                marginTop: 3,
-              }}
-            >
-              Citas
-            </div>
-          </div>
-          <div style={{ width: 1, background: 'var(--border-subtle)' }} />
-          <div style={{ textAlign: 'center' }}>
-            <div
-              style={{
-                fontFamily: 'var(--font-sans)',
-                fontSize: 'var(--text-lg)',
-                fontWeight: 'var(--fw-bold)',
-                color: 'var(--text-heading)',
-                lineHeight: 1,
-              }}
-            >
-              {s.rating}
-            </div>
-            <div
-              style={{
-                fontFamily: 'var(--font-sans)',
-                fontSize: 'var(--text-2xs)',
-                color: 'var(--text-muted)',
-                marginTop: 3,
-              }}
-            >
-              Rating
-            </div>
-          </div>
+      <Badge tone={rank === 1 ? 'rose' : 'neutral'} solid={rank === 1}>
+        #{rank}
+      </Badge>
+    </div>
+
+    <div style={{ display: 'flex', gap: 16 }}>
+      <div style={{ textAlign: 'center', flex: 1 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 'var(--text-xl)',
+            fontWeight: 'var(--fw-medium)',
+            color: 'var(--text-heading)',
+            lineHeight: 1,
+          }}
+        >
+          {money(s.rev)}
         </div>
-        <ProgressRing
-          value={s.utilization}
-          size={56}
-          thickness={5}
-          color={s.color || 'var(--chart-1)'}
-          label={`${utilPct}%`}
-          sublabel="uso"
-        />
+        <div
+          style={{
+            fontFamily: 'var(--font-sans)',
+            fontSize: 'var(--text-2xs)',
+            color: 'var(--text-muted)',
+            marginTop: 3,
+          }}
+        >
+          Ingresos
+        </div>
+      </div>
+      <div style={{ width: 1, background: 'var(--border-subtle)' }} />
+      <div style={{ textAlign: 'center', flex: 1 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-sans)',
+            fontSize: 'var(--text-lg)',
+            fontWeight: 'var(--fw-bold)',
+            color: 'var(--text-heading)',
+            lineHeight: 1,
+          }}
+        >
+          {money(s.avg)}
+        </div>
+        <div
+          style={{
+            fontFamily: 'var(--font-sans)',
+            fontSize: 'var(--text-2xs)',
+            color: 'var(--text-muted)',
+            marginTop: 3,
+          }}
+        >
+          Ticket prom.
+        </div>
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 export default StaffCard;

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -24,10 +24,7 @@ const Clients = ({ dateRange }) => {
   const { data: kpis } = useApi(() => api.kpis(dateRange), deps);
   const { data: retention } = useApi(() => api.clientRetention(dateRange), deps);
   const { data: stats } = useApi(() => api.clientStats(dateRange), deps);
-  const { data: clients, loading } = useApi(
-    () => api.clients({ search: search || undefined, limit: 100 }),
-    [search],
-  );
+  const { data: clients, loading } = useApi(() => api.clients({ search: search || undefined, limit: 100 }), [search]);
 
   const newClients = retention?.new_clients ?? kpis?.new_clients ?? 0;
   const recurringClients = retention?.recurring_clients ?? kpis?.recurring_clients ?? 0;
@@ -78,13 +75,7 @@ const Clients = ({ dateRange }) => {
       <div className="z-2col">
         <Card eyebrow="Segmentación" title="Lealtad de clientas">
           <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
-            <Donut
-              data={donutData}
-              size={150}
-              thickness={20}
-              centerValue={totalActive || 0}
-              centerLabel="activas"
-            />
+            <Donut data={donutData} size={150} thickness={20} centerValue={totalActive || 0} centerLabel="activas" />
             {donutData.length > 0 ? (
               <LegendRow
                 style={{ flexDirection: 'column', gap: 10 }}

--- a/src/pages/revenue.jsx
+++ b/src/pages/revenue.jsx
@@ -40,17 +40,14 @@ const Revenue = ({ dateRange, prevDateRange }) => {
   const { data: revByDayPrev } = useApi(() => api.revenueByDay(prevDateRange), prevDeps);
   const { data: paymentsData } = useApi(() => api.paymentMethodsBreakdown(dateRange), deps);
 
-  const revDelta =
-    kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
+  const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const ticketDelta =
-    kpis && kpisPrev?.avg_ticket
-      ? ((kpis.avg_ticket - kpisPrev.avg_ticket) / kpisPrev.avg_ticket) * 100
-      : 0;
+    kpis && kpisPrev?.avg_ticket ? ((kpis.avg_ticket - kpisPrev.avg_ticket) / kpisPrev.avg_ticket) * 100 : 0;
 
   const chartData = useMemo(() => revByDay?.map((r) => r.revenue) ?? [], [revByDay]);
   const chartLabels = useMemo(
     () => revByDay?.map((r) => `Día ${new Date(r.date + 'T00:00:00').getDate()}`) ?? [],
-    [revByDay],
+    [revByDay]
   );
 
   const bestDay = useMemo(() => {

--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -9,7 +9,6 @@ import Donut from '../components/charts/donut';
 import BarChart from '../components/charts/bar-chart';
 import DataTable from '../components/widgets/data-table';
 import Avatar from '../components/ui/avatar';
-import Badge from '../components/ui/badge';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
@@ -17,12 +16,10 @@ const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--char
 
 const COLUMNS = [
   { key: 'name', label: 'Empleada' },
-  { key: 'role', label: 'Rol' },
   { key: 'appts', label: 'Citas', align: 'right' },
   { key: 'clients', label: 'Clientas', align: 'right' },
+  { key: 'avg', label: 'Ticket prom.', align: 'right' },
   { key: 'rev', label: 'Ingresos', align: 'right' },
-  { key: 'rating', label: 'Rating', align: 'right' },
-  { key: 'utilization', label: 'Utilización', align: 'right' },
 ];
 
 const Staff = ({ dateRange }) => {
@@ -34,12 +31,10 @@ const Staff = ({ dateRange }) => {
       (staffData ?? []).map((s, i) => ({
         ...s,
         name: [s.first_name, s.last_name].filter(Boolean).join(' ') || `Profesional ${s.professional_id}`,
-        role: s.role ?? '—',
         rev: s.revenue ?? 0,
         appts: s.services_count ?? 0,
-        clients: s.clients_count ?? null,
-        rating: s.rating ?? '—',
-        utilization: s.utilization ?? 0,
+        clients: s.clients_count ?? 0,
+        avg: s.avg_ticket ?? 0,
         color: CHART[i % CHART.length],
       })),
     [staffData]
@@ -49,11 +44,6 @@ const Staff = ({ dateRange }) => {
   const totalRev = staff.reduce((acc, s) => acc + s.rev, 0);
   const totalAppts = staff.reduce((acc, s) => acc + s.appts, 0);
   const topStaff = staff[0] ?? null;
-
-  const ratedStaff = staff.filter((s) => s.rating !== '—' && !isNaN(Number(s.rating)));
-  const avgRating = ratedStaff.length
-    ? (ratedStaff.reduce((acc, s) => acc + Number(s.rating), 0) / ratedStaff.length).toFixed(1)
-    : null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
@@ -68,22 +58,22 @@ const Staff = ({ dateRange }) => {
         <StatCard
           label="Ingresos equipo"
           value={totalRev ? money(totalRev) : '—'}
-          caption="este mes"
+          caption="en el periodo"
           icon="TrendingUp"
           spark={[]}
           sparkColor="var(--chart-1)"
         />
         <StatCard
-          label="Rating promedio"
-          value={avgRating ? `★ ${avgRating}` : '—'}
-          caption={avgRating ? 'promedio del equipo' : 'sin datos'}
-          icon="Star"
-        />
-        <StatCard
           label="Total citas"
           value={totalAppts ? totalAppts.toLocaleString('es-MX') : '—'}
-          caption="este mes"
+          caption="en el periodo"
           icon="Calendar"
+        />
+        <StatCard
+          label="Empleadas activas"
+          value={staff.length ? String(staff.length) : '—'}
+          caption="con ventas en el periodo"
+          icon="Users"
         />
       </div>
 
@@ -154,7 +144,7 @@ const Staff = ({ dateRange }) => {
             key={s.name}
             rank={i + 1}
             label={s.name}
-            sublabel={`${s.appts} citas`}
+            sublabel={`${s.appts} citas · ${s.clients} clientas`}
             value={money(s.rev)}
             ratio={s.rev / maxRev}
             color={s.color}
@@ -176,13 +166,7 @@ const Staff = ({ dateRange }) => {
                 </div>
               );
             if (key === 'rev') return money(row.rev);
-            if (key === 'rating') return row.rating !== '—' ? `★ ${row.rating}` : '—';
-            if (key === 'utilization')
-              return (
-                <Badge tone={row.utilization > 0.8 ? 'positive' : row.utilization > 0.6 ? 'caution' : 'neutral'}>
-                  {row.utilization ? `${Math.round(row.utilization * 100)}%` : '—'}
-                </Badge>
-              );
+            if (key === 'avg') return money(row.avg);
             return row[key] ?? '—';
           }}
         />


### PR DESCRIPTION
## Summary

Removes UI elements that had no backing data, wires up real `clients_count` from the updated API.

**Removed (no data in DB):**
- `Rol` column in table + StaffCard subtitle
- `Rating` column in table + StaffCard stat + "Rating promedio" KPI card
- `Utilización` column in table + StaffCard ProgressRing

**Added / fixed:**
- `clients_count` now comes from the API (see zenya-api PR fix/staff-clients-count)
- StaffCard subtitle: "{clients} clientas · {appts} citas"
- StaffCard stats: Ingresos + Ticket prom. (both real data)
- "Rating promedio" KPI → **"Empleadas activas"** (count of staff with sales in period)
- Table columns: Empleada / Citas / Clientas / Ticket prom. / Ingresos
- RankRow sublabel: "{appts} citas · {clients} clientas"

Also fixes stale prettier violations in `revenue.jsx` and `clients.jsx`.

## Test plan

- [ ] Personal tab — all 4 KPI cards show real numbers
- [ ] Staff grid cards show Ingresos + Ticket prom. with no empty/— values
- [ ] Table shows Clientas column with real distinct-client counts
- [ ] No `—` placeholders remain for structural missing fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)