### PR TITLE
feat(views): implement all missing views from design sync

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
-import { PanelLeftClose, PanelLeftOpen, Menu } from 'lucide-react';
+import { PanelLeftClose, PanelLeftOpen, Menu, Sun, Moon } from 'lucide-react';
 
 import { api } from './lib/api';
 import { useApi } from './hooks/use-api';
@@ -7,7 +7,9 @@ import Sidebar from './components/layout/sidebar';
 import SectionTitle from './components/widgets/section-title';
 import DateRangePicker from './components/ui/date-range-picker';
 import { SkeletonCard } from './components/ui/skeleton';
+import IconButton from './components/ui/icon-button';
 
+import Login from './pages/login';
 import Overview from './pages/overview';
 import Revenue from './pages/revenue';
 import Services from './pages/services';
@@ -95,11 +97,13 @@ export function applyTheme(t) {
 }
 
 const App = () => {
+  const [authed, setAuthed] = useState(() => !!localStorage.getItem('zenya-auth-token'));
   const [active, setActive] = useState('overview');
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [dateRange, setDateRange] = useState(initialRange);
+  const [theme, setTheme] = useState(() => localStorage.getItem('zenya-theme') || 'light');
 
   const prevDateRange = useMemo(
     () => computePrevRange(dateRange.from_date, dateRange.to_date),
@@ -109,6 +113,10 @@ const App = () => {
   useEffect(() => {
     applyTheme(localStorage.getItem('zenya-theme') || 'light');
   }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
 
   const { data: ownerData } = useApi(() => api.userProfile(), []);
 
@@ -124,6 +132,16 @@ const App = () => {
     }, 480);
   };
 
+  const handleLogout = () => {
+    localStorage.removeItem('zenya-auth-token');
+    setAuthed(false);
+    setActive('overview');
+  };
+
+  if (!authed) {
+    return <Login onLogin={() => setAuthed(true)} />;
+  }
+
   return (
     <div style={{ display: 'flex', height: '100vh', background: 'var(--surface-page)', overflow: 'hidden' }}>
       <Sidebar
@@ -134,6 +152,7 @@ const App = () => {
         mobileOpen={mobileOpen}
         onCloseMobile={() => setMobileOpen(false)}
         owner={ownerData}
+        onLogout={handleLogout}
       />
 
       <main className="z-main">
@@ -185,6 +204,13 @@ const App = () => {
               {!HIDE_RANGE.has(active) && (
                 <DateRangePicker value={dateRange} onChange={setDateRange} className="z-hide-sm" />
               )}
+              <IconButton
+                label={theme === 'dark' ? 'Modo claro' : 'Modo oscuro'}
+                variant="outline"
+                onClick={() => setTheme((t) => (t === 'dark' ? 'light' : 'dark'))}
+              >
+                {theme === 'dark' ? <Sun size={16} strokeWidth={1.7} /> : <Moon size={16} strokeWidth={1.7} />}
+              </IconButton>
             </div>
           </div>
 

--- a/src/components/layout/sidebar.jsx
+++ b/src/components/layout/sidebar.jsx
@@ -2,7 +2,16 @@ import { LogOut } from 'lucide-react';
 import Avatar from '../ui/avatar';
 import { getIcon } from '../../lib/icons';
 
-const Sidebar = ({ active, onNavigate, items = [], collapsed = false, mobileOpen = false, onCloseMobile, owner }) => {
+const Sidebar = ({
+  active,
+  onNavigate,
+  items = [],
+  collapsed = false,
+  mobileOpen = false,
+  onCloseMobile,
+  owner,
+  onLogout,
+}) => {
   const ownerName = [owner?.first_name, owner?.last_name].filter(Boolean).join(' ') || 'Dueña';
   return (
     <>
@@ -175,6 +184,7 @@ const Sidebar = ({ active, onNavigate, items = [], collapsed = false, mobileOpen
               </div>
               <button
                 title="Cerrar sesión"
+                onClick={onLogout}
                 style={{
                   background: 'transparent',
                   border: 'none',

--- a/src/index.css
+++ b/src/index.css
@@ -82,6 +82,8 @@ html,body{margin:0;padding:0;background:var(--surface-page);color:var(--text-bod
 .z-staff-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px;}
 .z-status-row{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;}
 .z-appt-layout{display:grid;grid-template-columns:1.6fr 1fr;gap:20px;align-items:start;}
+.z-health-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;}
+.z-bucket-grid{display:grid;grid-template-columns:repeat(5,1fr);gap:16px;}
 .z-row{transition:background var(--dur-fast) var(--ease-soft);}
 .z-row:hover{background:var(--rose-50);}
 .z-sidebar{transition:width var(--dur-base) var(--ease-soft);}
@@ -91,6 +93,8 @@ html,body{margin:0;padding:0;background:var(--surface-page);color:var(--text-bod
 @media(max-width:1080px){
   .z-2col,.z-2col-wide,.z-staff-grid,.z-appt-layout{grid-template-columns:1fr;}
   .z-kpi-grid{grid-template-columns:repeat(2,1fr);}
+  .z-health-grid{grid-template-columns:repeat(2,1fr);}
+  .z-bucket-grid{grid-template-columns:repeat(3,1fr);}
   .z-spark{display:none;}
   .z-content{padding:22px 24px 56px;}
 }
@@ -101,6 +105,7 @@ html,body{margin:0;padding:0;background:var(--surface-page);color:var(--text-bod
   .z-menu-btn{display:inline-flex!important;}
   .z-collapse-btn{display:none!important;}
   .z-kpi-grid,.z-status-row{grid-template-columns:1fr;}
+  .z-health-grid,.z-bucket-grid{grid-template-columns:1fr;}
   .z-topbar{flex-direction:column;align-items:stretch;gap:16px;}
   .z-topbar-actions{flex-wrap:wrap;}
   .z-hide-sm{display:none!important;}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -9,6 +9,16 @@ async function get(path, params = {}) {
   return res.json();
 }
 
+async function post(path, body) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'X-API-Key': API_KEY, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`API ${res.status}: ${path}`);
+  return res.json();
+}
+
 async function put(path, body) {
   const res = await fetch(`${BASE_URL}${path}`, {
     method: 'PUT',
@@ -20,6 +30,10 @@ async function put(path, body) {
 }
 
 export const api = {
+  // auth
+  login: (email, password) => post('/auth/login', { email, password }),
+
+  // analytics — existing
   kpis: (params) => get('/analytics/kpis', params),
   revenueByDay: (params) => get('/analytics/revenue-by-day', params),
   topServices: (params) => get('/analytics/top-services', params),
@@ -27,6 +41,19 @@ export const api = {
   paymentMethodsBreakdown: (params) => get('/analytics/payment-methods-breakdown', params),
   clientRetention: (params) => get('/analytics/client-retention', params),
   clientStats: (params) => get('/analytics/client-stats', params),
+
+  // analytics — new endpoints (to be implemented in zenya-api)
+  healthScore: (params) => get('/analytics/health-score', params),
+  serviceCategories: (params) => get('/analytics/service-categories', params),
+  crossSell: (params) => get('/analytics/cross-sell', params),
+  serviceRepeatRate: (params) => get('/analytics/service-repeat-rate', params),
+  staffRepeatRate: (params) => get('/analytics/staff-repeat-rate', params),
+  clientProfiles: (params) => get('/analytics/client-profiles', params),
+  clvSegments: (params) => get('/analytics/clv-segments', params),
+  lowDemandServices: (params) => get('/analytics/low-demand-services', params),
+  acquisitionTrend: (params) => get('/analytics/acquisition-trend', params),
+
+  // resources
   sales: (params) => get('/sales', params),
   salesSummary: (params) => get('/sales/summary', params),
   bookings: (params) => get('/bookings', params),

--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -6,7 +6,13 @@ import Card from '../components/ui/card';
 import DataTable from '../components/widgets/data-table';
 import ApptStatus from '../components/widgets/appt-status';
 import Badge from '../components/ui/badge';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, CheckCircle, Clock, XCircle } from 'lucide-react';
+
+const PAYMENT_ICON_CARDS = [
+  { key: 'paid', label: 'Pagadas', icon: CheckCircle, bg: 'var(--positive-soft)', iconColor: 'var(--positive)' },
+  { key: 'pending', label: 'Pendientes', icon: Clock, bg: 'var(--caution-soft)', iconColor: 'var(--caution)' },
+  { key: 'unpaid', label: 'No pagadas', icon: XCircle, bg: 'var(--negative-soft)', iconColor: 'var(--negative)' },
+];
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 
@@ -183,9 +189,11 @@ const Appointments = () => {
     [bookings, profNames]
   );
 
-  const paid = rows.filter((r) => r.status === 'paid').length;
-  const pending = rows.filter((r) => r.status === 'pending').length;
+  const paid = rows.filter((r) => r.payment_status === 'ASSOCIATED' || r.status === 'paid').length;
+  const unpaid = rows.filter((r) => !r.payment_status || r.payment_status === 'UNPAID').length;
+  const pending = rows.length - paid - unpaid;
   const totalRev = rows.reduce((s, r) => s + (r.amount ?? 0), 0);
+  const paymentCounts = { paid, pending: Math.max(0, pending), unpaid };
 
   const displayDate = parseLocalDate(selectedDate).toLocaleDateString('es-MX', {
     weekday: 'long',
@@ -198,6 +206,62 @@ const Appointments = () => {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
+      {/* Styled payment-status cards */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
+        {PAYMENT_ICON_CARDS.map(({ key, label, icon: Icon, bg, iconColor }) => (
+          <div
+            key={key}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 14,
+              padding: '16px 18px',
+              borderRadius: 'var(--radius-lg)',
+              background: 'var(--surface-card)',
+              border: '1px solid var(--border-subtle)',
+            }}
+          >
+            <div
+              style={{
+                width: 44,
+                height: 44,
+                borderRadius: 'var(--radius-md)',
+                background: bg,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <Icon size={20} strokeWidth={1.8} color={iconColor} />
+            </div>
+            <div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-display)',
+                  fontSize: 'var(--text-2xl)',
+                  fontWeight: 700,
+                  color: 'var(--text-display)',
+                  lineHeight: 1.1,
+                }}
+              >
+                {loading ? '…' : paymentCounts[key]}
+              </div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                  color: 'var(--text-muted)',
+                  marginTop: 2,
+                }}
+              >
+                {label}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
       <div className="z-status-row">
         <StatCard
           label="Citas del día"

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { api } from '../lib/api';
 import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
@@ -7,17 +7,69 @@ import Donut from '../components/charts/donut';
 import BarChart from '../components/charts/bar-chart';
 import DataTable from '../components/widgets/data-table';
 import Avatar from '../components/ui/avatar';
-import LegendRow from '../components/ui/legend-row';
+import Badge from '../components/ui/badge';
+import SegmentedControl from '../components/ui/segmented-control';
 
+const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
+const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
 const pct = (v) => (v != null ? Math.round(v * 100) + '%' : '—');
 
-const CLIENT_COLS = [
-  { key: 'name', label: 'Clienta' },
-  { key: 'email', label: 'Email' },
-  { key: 'phone', label: 'Teléfono' },
+const TABS = [
+  { value: 'directorio', label: 'Directorio' },
+  { value: 'retencion', label: 'Retención' },
+  { value: 'clv', label: 'CLV & Segmentos' },
 ];
 
+const RETENTION_COLS = [
+  { key: 'name', label: 'Clienta' },
+  { key: 'last_visit', label: 'Última visita' },
+  { key: 'days_since', label: 'Días sin visitar', align: 'right' },
+  { key: 'avg_frequency', label: 'Frecuencia' },
+  { key: 'churn_status', label: 'Estado' },
+  { key: 'lifetime_revenue', label: 'Ingresos totales', align: 'right' },
+  { key: 'estimated_lost', label: 'Ingreso perdido', align: 'right' },
+];
+
+const VIP_COLS = [
+  { key: 'name', label: 'Clienta' },
+  { key: 'segment', label: 'Segmento' },
+  { key: 'total_visits', label: 'Visitas', align: 'right' },
+  { key: 'lifetime_revenue', label: 'Ingresos totales', align: 'right' },
+  { key: 'avg_ticket', label: 'Ticket prom.', align: 'right' },
+  { key: 'last_visit', label: 'Última visita' },
+  { key: 'days_since', label: 'Días desde', align: 'right' },
+];
+
+const SEG_TONE = { VIP: 'rose', Leal: 'lavender', Ocasional: 'caution', 'En riesgo': 'negative', Perdida: 'neutral' };
+
+function estadoBadge(e) {
+  if (e === 'active' || e === 'activa')
+    return (
+      <Badge tone="positive" size="sm" dot>
+        Activa
+      </Badge>
+    );
+  if (e === 'at_risk' || e === 'en_riesgo')
+    return (
+      <Badge tone="caution" size="sm" dot>
+        En riesgo
+      </Badge>
+    );
+  if (e === 'churned' || e === 'perdida')
+    return (
+      <Badge tone="negative" size="sm" dot>
+        Perdida
+      </Badge>
+    );
+  return (
+    <Badge tone="neutral" size="sm" dot>
+      Inactiva
+    </Badge>
+  );
+}
+
 const Clients = ({ dateRange }) => {
+  const [tab, setTab] = useState('directorio');
   const [search, setSearch] = useState('');
   const deps = [dateRange.from_date, dateRange.to_date];
 
@@ -25,7 +77,14 @@ const Clients = ({ dateRange }) => {
   const { data: retention } = useApi(() => api.clientRetention(dateRange), deps);
   const { data: stats } = useApi(() => api.clientStats(dateRange), deps);
   const { data: clients, loading } = useApi(() => api.clients({ search: search || undefined, limit: 100 }), [search]);
+  const { data: profilesData } = useApi(() => api.clientProfiles(dateRange), deps);
+  const { data: clvData } = useApi(() => api.clvSegments(dateRange), deps);
 
+  const visitsData = (stats?.visits_distribution ?? []).map((b) => ({
+    label: b.label,
+    value: b.count,
+  }));
+  const totalActive = retention?.active_clients ?? 0;
   const newClients = retention?.new_clients ?? kpis?.new_clients ?? 0;
   const recurringClients = retention?.recurring_clients ?? kpis?.recurring_clients ?? 0;
 
@@ -34,63 +93,413 @@ const Clients = ({ dateRange }) => {
     { label: 'Recurrentes', value: recurringClients, color: 'var(--chart-2)' },
   ].filter((d) => d.value > 0);
 
-  const visitsData = (stats?.visits_distribution ?? []).map((b) => ({
-    label: b.label,
-    value: b.count,
-  }));
+  // Retention tab data
+  const retentionProfiles = useMemo(
+    () => [...(profilesData ?? [])].sort((a, b) => (b.days_since_last ?? 0) - (a.days_since_last ?? 0)),
+    [profilesData]
+  );
+  const retentionKpis = useMemo(() => {
+    const all = profilesData ?? [];
+    return {
+      enRiesgo: all.filter((p) => p.churn_status === 'at_risk').length,
+      perdidas: all.filter((p) => p.churn_status === 'churned' || p.churn_status === 'lost').length,
+      reactivadas: retention?.reactivated_clients ?? 0,
+      retencionPct: retention?.retention_rate ?? null,
+    };
+  }, [profilesData, retention]);
 
-  const totalActive = retention?.active_clients ?? 0;
+  const churnBuckets = useMemo(() => {
+    const all = profilesData ?? [];
+    return [30, 60, 90, 180, 365].map((d) => ({
+      label: `+${d} días`,
+      count: all.filter((p) => (p.days_since_last ?? 0) >= d).length,
+    }));
+  }, [profilesData]);
+
+  // CLV tab data
+  const clvSegments = useMemo(() => {
+    if (!clvData?.segments?.length) return [];
+    return clvData.segments.map((s, i) => ({
+      ...s,
+      color: `var(--chart-${(i % 5) + 1})`,
+    }));
+  }, [clvData]);
+  const clvTotal = clvSegments.reduce((s, c) => s + (c.revenue ?? 0), 0);
+  const vipClients = clvData?.top_clients ?? [];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
-      <div className="z-kpi-grid">
-        <StatCard
-          label="Total clientes"
-          value={(kpis?.distinct_clients ?? 0).toLocaleString('es-MX')}
-          caption="activas en el periodo"
-          icon="Users"
-          spark={[]}
-          sparkColor="var(--chart-1)"
-        />
-        <StatCard
-          label="Clientas VIP"
-          value={stats ? stats.vip_count.toLocaleString('es-MX') : '—'}
-          caption="4+ visitas históricas"
-          icon="Star"
-        />
-        <StatCard
-          label="Retención"
-          value={retention ? pct(retention.retention_rate) : '—'}
-          caption="clientas que regresaron"
-          icon="TrendingUp"
-        />
-        <StatCard
-          label="Ticket promedio"
-          value={kpis ? '$' + Math.round(kpis.avg_ticket).toLocaleString('es-MX') : '—'}
-          caption="este periodo"
-          icon="DollarSign"
-        />
-      </div>
+      <SegmentedControl value={tab} onChange={setTab} options={TABS} />
 
-      <div className="z-2col">
-        <Card eyebrow="Segmentación" title="Lealtad de clientas">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
-            <Donut data={donutData} size={150} thickness={20} centerValue={totalActive || 0} centerLabel="activas" />
-            {donutData.length > 0 ? (
-              <LegendRow
-                style={{ flexDirection: 'column', gap: 10 }}
-                items={donutData.map((d) => ({
-                  label: d.label,
-                  value: d.value,
-                  color: d.color,
+      {/* ── DIRECTORIO TAB ── */}
+      {tab === 'directorio' && (
+        <>
+          <div className="z-kpi-grid">
+            <StatCard
+              label="Total clientes"
+              value={(kpis?.distinct_clients ?? 0).toLocaleString('es-MX')}
+              caption="activas en el periodo"
+              icon="Users"
+              spark={[]}
+              sparkColor="var(--chart-1)"
+            />
+            <StatCard
+              label="Clientas VIP"
+              value={stats ? stats.vip_count.toLocaleString('es-MX') : '—'}
+              caption="4+ visitas históricas"
+              icon="Star"
+            />
+            <StatCard
+              label="Retención"
+              value={retention ? pct(retention.retention_rate) : '—'}
+              caption="clientas que regresaron"
+              icon="TrendingUp"
+            />
+            <StatCard
+              label="Ticket promedio"
+              value={kpis ? '$' + Math.round(kpis.avg_ticket).toLocaleString('es-MX') : '—'}
+              caption="este periodo"
+              icon="DollarSign"
+            />
+          </div>
+
+          <div className="z-2col">
+            <Card eyebrow="Segmentación" title="Lealtad de clientas">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
+                <Donut
+                  data={donutData}
+                  size={150}
+                  thickness={20}
+                  centerValue={totalActive || 0}
+                  centerLabel="activas"
+                />
+                {donutData.length > 0 ? (
+                  <div style={{ flex: 1, minWidth: 120, display: 'flex', flexDirection: 'column', gap: 10 }}>
+                    {donutData.map((d, i) => (
+                      <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <span
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 8,
+                            fontFamily: 'var(--font-sans)',
+                            fontSize: 'var(--text-sm)',
+                            color: 'var(--text-secondary)',
+                          }}
+                        >
+                          <span style={{ width: 10, height: 10, borderRadius: 3, background: d.color }} />
+                          {d.label}
+                        </span>
+                        <span
+                          style={{
+                            fontFamily: 'var(--font-sans)',
+                            fontSize: 'var(--text-sm)',
+                            fontWeight: 600,
+                            color: 'var(--text-display)',
+                          }}
+                        >
+                          {d.value}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </Card>
+
+            <Card eyebrow="Frecuencia" title="Visitas por clienta">
+              {visitsData.length > 0 ? (
+                <BarChart data={visitsData} height={200} yFormat={(v) => v} />
+              ) : (
+                <div
+                  style={{
+                    height: 200,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: 'var(--text-muted)',
+                    fontFamily: 'var(--font-sans)',
+                    fontSize: 'var(--text-sm)',
+                  }}
+                >
+                  Sin datos en el periodo
+                </div>
+              )}
+            </Card>
+          </div>
+
+          <Card
+            eyebrow="Directorio"
+            title="Clientes"
+            action={
+              <input
+                placeholder="Buscar..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                style={{
+                  padding: '4px 10px',
+                  borderRadius: 6,
+                  border: '1px solid var(--border-subtle)',
+                  fontSize: 'var(--text-sm)',
+                  fontFamily: 'var(--font-sans)',
+                  background: 'var(--surface-card)',
+                  color: 'var(--text-body)',
+                }}
+              />
+            }
+          >
+            {loading ? (
+              <div
+                style={{
+                  padding: '20px 0',
+                  textAlign: 'center',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                }}
+              >
+                Cargando...
+              </div>
+            ) : (
+              <DataTable
+                columns={[
+                  { key: 'name', label: 'Clienta' },
+                  { key: 'email', label: 'Email' },
+                  { key: 'phone', label: 'Teléfono' },
+                ]}
+                rows={(clients ?? []).map((c) => ({
+                  ...c,
+                  name: [c.first_name, c.last_name].filter(Boolean).join(' ') || '—',
                 }))}
+                renderCell={(row, key) => {
+                  if (key === 'name')
+                    return (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <Avatar name={row.name} size="sm" tone="ink" />
+                        <span style={{ fontWeight: 'var(--fw-medium)', color: 'var(--text-heading)' }}>{row.name}</span>
+                      </div>
+                    );
+                  return row[key] ?? '—';
+                }}
+              />
+            )}
+          </Card>
+        </>
+      )}
+
+      {/* ── RETENCIÓN TAB ── */}
+      {tab === 'retencion' && (
+        <>
+          <div className="z-kpi-grid">
+            <StatCard
+              label="En riesgo"
+              value={String(retentionKpis.enRiesgo)}
+              caption="clientas"
+              icon="AlertTriangle"
+              numeralStyle="sans"
+            />
+            <StatCard
+              label="Perdidas"
+              value={String(retentionKpis.perdidas)}
+              caption="sin volver +90d"
+              icon="UserX"
+              numeralStyle="sans"
+            />
+            <StatCard
+              label="Reactivadas"
+              value={String(retentionKpis.reactivadas)}
+              caption="este mes"
+              icon="UserCheck"
+              numeralStyle="sans"
+            />
+            <StatCard
+              label="Retención"
+              value={retentionKpis.retencionPct != null ? pct(retentionKpis.retencionPct) : '—'}
+              caption="vs mes anterior"
+              icon="Repeat"
+              numeralStyle="sans"
+            />
+          </div>
+
+          <Card eyebrow="Riesgo de fuga" title="Clasificación de clientas">
+            {retentionProfiles.length > 0 ? (
+              <DataTable
+                columns={RETENTION_COLS}
+                rows={retentionProfiles}
+                renderCell={(row, key) => {
+                  if (key === 'name') {
+                    const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
+                    return (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <Avatar name={name} size="sm" tone="ink" />
+                        <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{name}</span>
+                      </div>
+                    );
+                  }
+                  if (key === 'last_visit')
+                    return <span style={{ color: 'var(--text-secondary)' }}>{row.last_visit ?? '—'}</span>;
+                  if (key === 'days_since') {
+                    const d = row.days_since_last ?? 0;
+                    return (
+                      <span
+                        style={{
+                          fontWeight: 600,
+                          color: d > 90 ? 'var(--negative)' : d > 45 ? 'var(--caution)' : 'var(--text-body)',
+                        }}
+                      >
+                        {d} d
+                      </span>
+                    );
+                  }
+                  if (key === 'avg_frequency')
+                    return <span style={{ color: 'var(--text-secondary)' }}>{row.avg_frequency ?? '—'}</span>;
+                  if (key === 'churn_status') return estadoBadge(row.churn_status);
+                  if (key === 'lifetime_revenue') return money(row.lifetime_revenue ?? 0);
+                  if (key === 'estimated_lost')
+                    return row.estimated_lost ? (
+                      <span style={{ fontWeight: 600, color: 'var(--negative)' }}>{money(row.estimated_lost)}</span>
+                    ) : (
+                      <span style={{ color: 'var(--text-muted)' }}>—</span>
+                    );
+                  return row[key] ?? '—';
+                }}
               />
             ) : (
               <div
                 style={{
-                  flex: 1,
-                  minWidth: 120,
-                  padding: '12px 0',
+                  padding: '20px 0',
+                  textAlign: 'center',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                }}
+              >
+                Sin datos de retención
+              </div>
+            )}
+          </Card>
+
+          <div>
+            <div
+              style={{
+                fontFamily: 'var(--font-label)',
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: 'var(--ls-label)',
+                textTransform: 'uppercase',
+                color: 'var(--text-brand)',
+                marginBottom: 14,
+              }}
+            >
+              Tiempo sin regresar
+            </div>
+            <div className="z-bucket-grid">
+              {churnBuckets.map((b, i) => (
+                <Card key={i} padding="var(--space-5)" interactive>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-display)',
+                      fontSize: 'var(--text-3xl)',
+                      fontWeight: 600,
+                      color: 'var(--text-display)',
+                      lineHeight: 1,
+                    }}
+                  >
+                    {b.count}
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: 'var(--text-sm)',
+                      color: 'var(--text-muted)',
+                      marginTop: 6,
+                    }}
+                  >
+                    {b.label}
+                  </div>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* ── CLV & SEGMENTOS TAB ── */}
+      {tab === 'clv' && (
+        <>
+          <Card eyebrow="Valor" title="Ingresos por segmento">
+            {clvSegments.length > 0 ? (
+              <div style={{ display: 'flex', gap: 32, alignItems: 'center', flexWrap: 'wrap' }}>
+                <Donut
+                  data={clvSegments.map((s) => ({ value: s.revenue ?? 0, color: s.color }))}
+                  size={190}
+                  thickness={24}
+                  centerValue={clvTotal ? moneyK(clvTotal) : '—'}
+                  centerLabel="ingresos"
+                />
+                <div style={{ flex: 1, minWidth: 240, display: 'flex', flexDirection: 'column', gap: 0 }}>
+                  {clvSegments.map((s, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 12,
+                        padding: '12px 0',
+                        borderBottom: i < clvSegments.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+                      }}
+                    >
+                      <span style={{ width: 12, height: 12, borderRadius: 3, background: s.color, flexShrink: 0 }} />
+                      <div style={{ flex: 1 }}>
+                        <div
+                          style={{
+                            fontFamily: 'var(--font-sans)',
+                            fontSize: 'var(--text-base)',
+                            fontWeight: 600,
+                            color: 'var(--text-heading)',
+                          }}
+                        >
+                          {s.segment ?? s.name}
+                        </div>
+                        <div
+                          style={{
+                            fontFamily: 'var(--font-sans)',
+                            fontSize: 'var(--text-xs)',
+                            color: 'var(--text-muted)',
+                          }}
+                        >
+                          {s.count} clientas
+                        </div>
+                      </div>
+                      <div style={{ textAlign: 'right' }}>
+                        <div
+                          style={{
+                            fontFamily: 'var(--font-sans)',
+                            fontSize: 'var(--text-base)',
+                            fontWeight: 600,
+                            color: 'var(--text-display)',
+                          }}
+                        >
+                          {money(s.revenue ?? 0)}
+                        </div>
+                        <div
+                          style={{
+                            fontFamily: 'var(--font-sans)',
+                            fontSize: 'var(--text-xs)',
+                            color: 'var(--text-muted)',
+                          }}
+                        >
+                          {clvTotal ? Math.round(((s.revenue ?? 0) / clvTotal) * 100) : 0}%
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div
+                style={{
+                  padding: '20px 0',
                   textAlign: 'center',
                   color: 'var(--text-muted)',
                   fontFamily: 'var(--font-sans)',
@@ -100,82 +509,61 @@ const Clients = ({ dateRange }) => {
                 Sin datos de segmentación
               </div>
             )}
-          </div>
-        </Card>
+          </Card>
 
-        <Card eyebrow="Frecuencia" title="Visitas por clienta">
-          {visitsData.length > 0 ? (
-            <BarChart data={visitsData} height={200} yFormat={(v) => v} />
-          ) : (
-            <div
-              style={{
-                height: 200,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                color: 'var(--text-muted)',
-                fontFamily: 'var(--font-sans)',
-                fontSize: 'var(--text-sm)',
-              }}
-            >
-              Sin datos en el periodo
-            </div>
-          )}
-        </Card>
-      </div>
-
-      <Card
-        eyebrow="Directorio"
-        title="Clientes"
-        action={
-          <input
-            placeholder="Buscar..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            style={{
-              padding: '4px 10px',
-              borderRadius: 6,
-              border: '1px solid var(--border-subtle)',
-              fontSize: 'var(--text-sm)',
-              fontFamily: 'var(--font-sans)',
-              background: 'var(--bg-surface)',
-              color: 'var(--text-body)',
-            }}
-          />
-        }
-      >
-        {loading ? (
-          <div
-            style={{
-              padding: '20px 0',
-              textAlign: 'center',
-              color: 'var(--text-muted)',
-              fontFamily: 'var(--font-sans)',
-              fontSize: 'var(--text-sm)',
-            }}
-          >
-            Cargando...
-          </div>
-        ) : (
-          <DataTable
-            columns={CLIENT_COLS}
-            rows={(clients ?? []).map((c) => ({
-              ...c,
-              name: [c.first_name, c.last_name].filter(Boolean).join(' ') || '—',
-            }))}
-            renderCell={(row, key) => {
-              if (key === 'name')
-                return (
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                    <Avatar name={row.name} size="sm" tone="ink" />
-                    <span style={{ fontWeight: 'var(--fw-medium)', color: 'var(--text-heading)' }}>{row.name}</span>
-                  </div>
-                );
-              return row[key] ?? '—';
-            }}
-          />
-        )}
-      </Card>
+          <Card eyebrow="Valor de vida" title="Top 10 clientas VIP">
+            {vipClients.length > 0 ? (
+              <DataTable
+                columns={VIP_COLS}
+                rows={vipClients}
+                renderCell={(row, key) => {
+                  if (key === 'name') {
+                    const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || row.name || '—';
+                    return (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <Avatar name={name} size="sm" tone="rose" />
+                        <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{name}</span>
+                      </div>
+                    );
+                  }
+                  if (key === 'segment') {
+                    const seg = row.segment ?? '—';
+                    return (
+                      <Badge tone={SEG_TONE[seg] ?? 'neutral'} size="sm" dot>
+                        {seg}
+                      </Badge>
+                    );
+                  }
+                  if (key === 'lifetime_revenue')
+                    return (
+                      <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>
+                        {money(row.lifetime_revenue ?? 0)}
+                      </span>
+                    );
+                  if (key === 'avg_ticket') return money(row.avg_ticket ?? 0);
+                  if (key === 'last_visit')
+                    return <span style={{ color: 'var(--text-secondary)' }}>{row.last_visit ?? '—'}</span>;
+                  if (key === 'days_since')
+                    return <span style={{ color: 'var(--text-secondary)' }}>{row.days_since_last ?? '—'} d</span>;
+                  return row[key] ?? '—';
+                }}
+              />
+            ) : (
+              <div
+                style={{
+                  padding: '20px 0',
+                  textAlign: 'center',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                }}
+              >
+                Sin datos de clientas VIP
+              </div>
+            )}
+          </Card>
+        </>
+      )}
     </div>
   );
 };

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -1,0 +1,241 @@
+import { useState } from 'react';
+import { Eye, EyeOff, Lock, Mail } from 'lucide-react';
+import { api } from '../lib/api';
+
+const Login = ({ onLogin }) => {
+  const [email, setEmail] = useState('');
+  const [pass, setPass] = useState('');
+  const [show, setShow] = useState(false);
+  const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError(false);
+    setLoading(true);
+    try {
+      const res = await api.login(email, pass);
+      if (res?.token) localStorage.setItem('zenya-auth-token', res.token);
+      onLogin && onLogin(res);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const inputBox = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    height: 46,
+    padding: '0 14px',
+    background: 'var(--surface-card)',
+    border: '1px solid var(--border-strong)',
+    borderRadius: 'var(--radius-md)',
+  };
+  const inputEl = {
+    flex: 1,
+    border: 'none',
+    outline: 'none',
+    background: 'transparent',
+    fontFamily: 'var(--font-sans)',
+    fontSize: 'var(--text-base)',
+    color: 'var(--text-body)',
+    minWidth: 0,
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'var(--surface-page)',
+        padding: 24,
+        boxSizing: 'border-box',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 420,
+          background: 'var(--surface-card)',
+          border: '1px solid var(--border-subtle)',
+          borderRadius: 'var(--radius-xl)',
+          boxShadow: 'var(--shadow-lg)',
+          padding: '40px 36px',
+          boxSizing: 'border-box',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            textAlign: 'center',
+            marginBottom: 28,
+          }}
+        >
+          <img
+            src="/zenya-mark-rose.png"
+            alt="Zenya"
+            style={{ height: 52, width: 'auto', marginBottom: 12 }}
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+            }}
+          />
+          <div
+            style={{
+              fontFamily: 'var(--font-display)',
+              fontSize: 'var(--text-3xl)',
+              fontWeight: 600,
+              color: 'var(--text-display)',
+              lineHeight: 1,
+              letterSpacing: 'var(--ls-tight)',
+            }}
+          >
+            zenya
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--font-label)',
+              fontSize: 'var(--text-xs)',
+              fontWeight: 600,
+              letterSpacing: 'var(--ls-label)',
+              textTransform: 'uppercase',
+              color: 'var(--text-muted)',
+              marginTop: 8,
+            }}
+          >
+            Nails &amp; Spa · Panel de administración
+          </div>
+        </div>
+
+        <form onSubmit={submit} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+            <span
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 'var(--fw-semibold)',
+                color: 'var(--text-heading)',
+              }}
+            >
+              Correo electrónico
+            </span>
+            <div style={inputBox}>
+              <Mail size={17} strokeWidth={1.7} color="var(--text-muted)" style={{ flexShrink: 0 }} />
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                style={inputEl}
+                placeholder="tu@correo.com"
+                required
+                autoComplete="email"
+              />
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+            <span
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 'var(--fw-semibold)',
+                color: 'var(--text-heading)',
+              }}
+            >
+              Contraseña
+            </span>
+            <div style={inputBox}>
+              <Lock size={17} strokeWidth={1.7} color="var(--text-muted)" style={{ flexShrink: 0 }} />
+              <input
+                type={show ? 'text' : 'password'}
+                value={pass}
+                onChange={(e) => setPass(e.target.value)}
+                style={inputEl}
+                placeholder="••••••••"
+                required
+                autoComplete="current-password"
+              />
+              <button
+                type="button"
+                onClick={() => setShow((s) => !s)}
+                aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                style={{
+                  border: 'none',
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  color: 'var(--text-muted)',
+                  display: 'inline-flex',
+                  padding: 0,
+                  flexShrink: 0,
+                }}
+              >
+                {show ? <EyeOff size={18} strokeWidth={1.7} /> : <Eye size={18} strokeWidth={1.7} />}
+              </button>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            style={{
+              height: 48,
+              width: '100%',
+              marginTop: 4,
+              background: loading ? 'var(--ink-300)' : 'var(--brand-primary)',
+              color: 'var(--white)',
+              border: 'none',
+              borderRadius: 'var(--radius-md)',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--text-base)',
+              fontWeight: 'var(--fw-semibold)',
+              cursor: loading ? 'not-allowed' : 'pointer',
+              transition: 'background var(--dur-fast) var(--ease-soft)',
+            }}
+          >
+            {loading ? 'Iniciando sesión…' : 'Iniciar sesión'}
+          </button>
+
+          {error && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                alignSelf: 'center',
+                padding: '6px 14px',
+                borderRadius: 'var(--radius-pill)',
+                background: 'var(--negative-soft)',
+                color: 'var(--negative)',
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+                fontWeight: 600,
+              }}
+            >
+              Credenciales incorrectas
+            </div>
+          )}
+        </form>
+
+        <div
+          style={{
+            textAlign: 'center',
+            marginTop: 28,
+            fontFamily: 'var(--font-sans)',
+            fontSize: 'var(--text-2xs)',
+            color: 'var(--text-muted)',
+          }}
+        >
+          © 2026 Zenya Nails &amp; Spa
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/overview.jsx
+++ b/src/pages/overview.jsx
@@ -5,7 +5,7 @@ import StatCard from '../components/widgets/stat-card';
 import Card from '../components/ui/card';
 import AreaChart from '../components/charts/area-chart';
 import RankRow from '../components/widgets/rank-row';
-import Avatar from '../components/ui/avatar';
+import StaffCard from '../components/widgets/staff-card';
 import LegendRow from '../components/ui/legend-row';
 import SegmentedControl from '../components/ui/segmented-control';
 import { Clock, TrendingUp, TrendingDown, Sparkles, Award, Calendar, Heart } from 'lucide-react';
@@ -19,6 +19,12 @@ const INSIGHT_COLORS = {
   positive: { bg: 'var(--lavender-50)', fg: 'var(--green-600)' },
   caution: { bg: 'var(--lavender-50)', fg: 'var(--amber-600)' },
   neutral: { bg: 'var(--lavender-50)', fg: 'var(--lavender-500)' },
+};
+
+const HEALTH_COLORS = {
+  green: { dot: 'var(--green-500)', soft: 'var(--positive-soft)' },
+  amber: { dot: 'var(--amber-500)', soft: 'var(--caution-soft)' },
+  red: { dot: 'var(--red-500)', soft: 'var(--negative-soft)' },
 };
 
 function computeInsights({ kpis, kpisPrev, topServices, staffData, revByDay }) {
@@ -87,6 +93,7 @@ const Overview = ({ dateRange, prevDateRange }) => {
   const { data: topServices } = useApi(() => api.topServices({ ...dateRange, limit: 5 }), deps);
   const { data: staffData } = useApi(() => api.staffPerformance(dateRange), deps);
   const { data: recentBookings } = useApi(() => api.bookings({ ...dateRange, limit: 6 }), deps);
+  const { data: healthData } = useApi(() => api.healthScore(dateRange), deps);
 
   const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const apptDelta =
@@ -100,11 +107,27 @@ const Overview = ({ dateRange, prevDateRange }) => {
   const chartLabels = useMemo(() => revByDay?.map((r) => `Día ${new Date(r.date).getDate()}`) ?? [], [revByDay]);
   const maxServiceRev = topServices?.length ? Math.max(...topServices.map((s) => s.revenue)) : 1;
   const bookings = recentBookings ?? [];
-  const staff = staffData ?? [];
+
+  const staff = useMemo(
+    () =>
+      (staffData ?? []).map((s, i) => ({
+        ...s,
+        name: [s.first_name, s.last_name].filter(Boolean).join(' ') || `Profesional ${s.professional_id}`,
+        rev: s.revenue ?? 0,
+        appts: s.services_count ?? 0,
+        clients: s.clients_count ?? 0,
+        avg: s.avg_ticket ?? 0,
+        color: CHART[i % CHART.length],
+      })),
+    [staffData]
+  );
+
   const insights = useMemo(
     () => computeInsights({ kpis, kpisPrev, topServices, staffData, revByDay }),
     [kpis, kpisPrev, topServices, staffData, revByDay]
   );
+
+  const healthMetrics = healthData?.metrics ?? [];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
@@ -311,74 +334,107 @@ const Overview = ({ dateRange, prevDateRange }) => {
         </Card>
       </div>
 
-      <Card eyebrow="Personal" title="Rendimiento del equipo">
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
-          {staff.map((s, i) => {
-            const name = [s.first_name, s.last_name].filter(Boolean).join(' ') || `Profesional ${s.professional_id}`;
-            return (
-              <div
-                key={s.professional_id}
-                className="z-row"
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 14,
-                  padding: '12px 0',
-                  borderBottom: i < staff.length - 1 ? '1px solid var(--border-subtle)' : 'none',
-                }}
-              >
-                <Avatar name={name} size="sm" tone={i === 0 ? 'rose' : i === 1 ? 'lavender' : 'ink'} />
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div
+      {/* Business health scorecard */}
+      {healthMetrics.length > 0 && (
+        <Card eyebrow="Diagnóstico" title="Salud del negocio">
+          <div className="z-health-grid">
+            {healthMetrics.map((m, i) => {
+              const c = HEALTH_COLORS[m.status] ?? HEALTH_COLORS.amber;
+              return (
+                <div
+                  key={i}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 12,
+                    padding: '13px 14px',
+                    borderRadius: 'var(--radius-md)',
+                    background: c.soft,
+                  }}
+                >
+                  <span
                     style={{
-                      fontFamily: 'var(--font-sans)',
-                      fontSize: 'var(--text-sm)',
-                      fontWeight: 'var(--fw-medium)',
-                      color: 'var(--text-heading)',
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      background: c.dot,
+                      flexShrink: 0,
+                      marginTop: 5,
                     }}
-                  >
-                    {name}
+                  />
+                  <div style={{ minWidth: 0 }}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'baseline',
+                        gap: 8,
+                        flexWrap: 'wrap',
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-sm)',
+                          fontWeight: 'var(--fw-semibold)',
+                          color: 'var(--text-heading)',
+                        }}
+                      >
+                        {m.name}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-sm)',
+                          fontWeight: 'var(--fw-medium)',
+                          color: 'var(--text-body)',
+                        }}
+                      >
+                        {m.value}
+                      </span>
+                    </div>
+                    {m.note && (
+                      <div
+                        style={{
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-xs)',
+                          color: 'var(--text-muted)',
+                          marginTop: 2,
+                        }}
+                      >
+                        {m.note}
+                      </div>
+                    )}
                   </div>
                 </div>
-                <div style={{ textAlign: 'right' }}>
-                  <div
-                    style={{
-                      fontFamily: 'var(--font-sans)',
-                      fontSize: 'var(--text-sm)',
-                      fontWeight: 'var(--fw-semibold)',
-                      color: 'var(--text-heading)',
-                    }}
-                  >
-                    {money(s.revenue)}
-                  </div>
-                  <div
-                    style={{
-                      fontFamily: 'var(--font-sans)',
-                      fontSize: 'var(--text-xs)',
-                      color: 'var(--text-muted)',
-                    }}
-                  >
-                    {s.services_count ?? 0} citas
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-          {!staff.length && (
-            <div
-              style={{
-                padding: '20px 0',
-                textAlign: 'center',
-                color: 'var(--text-muted)',
-                fontFamily: 'var(--font-sans)',
-                fontSize: 'var(--text-sm)',
-              }}
-            >
-              Sin datos de personal
-            </div>
-          )}
+              );
+            })}
+          </div>
+        </Card>
+      )}
+
+      {/* Staff performance grid */}
+      {staff.length > 0 && (
+        <div>
+          <div
+            style={{
+              fontFamily: 'var(--font-label)',
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: 'var(--ls-label)',
+              textTransform: 'uppercase',
+              color: 'var(--text-brand)',
+              marginBottom: 14,
+            }}
+          >
+            Rendimiento del equipo
+          </div>
+          <div className="z-staff-grid">
+            {staff.map((s, i) => (
+              <StaffCard key={s.name} s={s} rank={i + 1} maxRev={Math.max(...staff.map((x) => x.rev))} money={money} />
+            ))}
+          </div>
         </div>
-      </Card>
+      )}
     </div>
   );
 };

--- a/src/pages/revenue.jsx
+++ b/src/pages/revenue.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { api } from '../lib/api';
 import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
@@ -6,9 +6,9 @@ import Card from '../components/ui/card';
 import AreaChart from '../components/charts/area-chart';
 import Donut from '../components/charts/donut';
 import ProgressBar from '../components/charts/progress-bar';
-import GroupedBars from '../components/charts/grouped-bars';
 import DataTable from '../components/widgets/data-table';
 import LegendRow from '../components/ui/legend-row';
+import SegmentedControl from '../components/ui/segmented-control';
 import DeltaBadge from '../components/ui/delta-badge';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
@@ -22,6 +22,8 @@ const METHOD_LABELS = {
   wire_transfer: 'Transferencia',
 };
 
+const LOW_TONE_COLOR = { amber: 'var(--amber-500)', red: 'var(--red-500)' };
+
 const COLUMNS = [
   { key: 'label', label: 'Día' },
   { key: 'cur', label: 'Este período', align: 'right' },
@@ -31,6 +33,7 @@ const COLUMNS = [
 ];
 
 const Revenue = ({ dateRange, prevDateRange }) => {
+  const [cmp, setCmp] = useState('prev');
   const deps = [dateRange.from_date, dateRange.to_date];
   const prevDeps = [prevDateRange.from_date, prevDateRange.to_date];
 
@@ -39,12 +42,21 @@ const Revenue = ({ dateRange, prevDateRange }) => {
   const { data: revByDay } = useApi(() => api.revenueByDay(dateRange), deps);
   const { data: revByDayPrev } = useApi(() => api.revenueByDay(prevDateRange), prevDeps);
   const { data: paymentsData } = useApi(() => api.paymentMethodsBreakdown(dateRange), deps);
+  const { data: categoriesData } = useApi(() => api.serviceCategories(dateRange), deps);
+  const { data: lowDemandData } = useApi(() => api.lowDemandServices(dateRange), deps);
 
   const revDelta = kpis && kpisPrev?.revenue ? ((kpis.revenue - kpisPrev.revenue) / kpisPrev.revenue) * 100 : 0;
   const ticketDelta =
     kpis && kpisPrev?.avg_ticket ? ((kpis.avg_ticket - kpisPrev.avg_ticket) / kpisPrev.avg_ticket) * 100 : 0;
 
+  const revenuePerAppt = kpis?.revenue && kpis?.bookings_count ? Math.round(kpis.revenue / kpis.bookings_count) : null;
+  const revenuePerApptPrev =
+    kpisPrev?.revenue && kpisPrev?.bookings_count ? Math.round(kpisPrev.revenue / kpisPrev.bookings_count) : null;
+  const revenuePerApptDelta =
+    revenuePerAppt && revenuePerApptPrev ? ((revenuePerAppt - revenuePerApptPrev) / revenuePerApptPrev) * 100 : null;
+
   const chartData = useMemo(() => revByDay?.map((r) => r.revenue) ?? [], [revByDay]);
+  const chartCompare = useMemo(() => revByDayPrev?.map((r) => r.revenue) ?? [], [revByDayPrev]);
   const chartLabels = useMemo(
     () => revByDay?.map((r) => `Día ${new Date(r.date + 'T00:00:00').getDate()}`) ?? [],
     [revByDay]
@@ -61,6 +73,19 @@ const Revenue = ({ dateRange, prevDateRange }) => {
     if (!total) return [];
     return paymentsData.map((p) => ({ ...p, pct: p.total / total }));
   }, [paymentsData]);
+
+  const categories = useMemo(() => {
+    if (!categoriesData?.length) return [];
+    const total = categoriesData.reduce((s, c) => s + c.revenue, 0);
+    return categoriesData.map((c, i) => ({
+      ...c,
+      color: `var(--chart-${(i % 5) + 1})`,
+      pct: total ? c.revenue / total : 0,
+    }));
+  }, [categoriesData]);
+  const catTotal = categories.reduce((s, c) => s + c.revenue, 0);
+
+  const lowDemand = lowDemandData ?? [];
 
   const dailyRows = useMemo(() => {
     if (!revByDay?.length) return [];
@@ -113,55 +138,111 @@ const Revenue = ({ dateRange, prevDateRange }) => {
           }
           icon="Star"
         />
-        <StatCard label="Meta mensual" value="—" caption="sin configurar" icon="Target" />
+        <StatCard
+          label="Ingresos por cita"
+          value={revenuePerAppt ? money(revenuePerAppt) : '—'}
+          delta={revenuePerApptDelta}
+          caption="vs período anterior"
+          icon="Receipt"
+          numeralStyle="sans"
+        />
       </div>
 
-      <div className="z-2col-wide">
-        <Card eyebrow="Ingresos" title="Evolución de ingresos">
-          <LegendRow
-            items={[
-              { label: 'Este período', color: 'var(--chart-1)', line: true },
-              { label: 'Período anterior', color: 'var(--chart-compare)', line: true, dashed: true },
+      <Card
+        eyebrow="Tendencia"
+        title="Evolución de ingresos"
+        action={
+          <SegmentedControl
+            size="sm"
+            value={cmp}
+            onChange={setCmp}
+            options={[
+              { value: 'prev', label: 'Mes anterior' },
+              { value: 'yoy', label: 'Año anterior' },
             ]}
-            style={{ marginBottom: 14 }}
           />
-          <AreaChart data={chartData} labels={chartLabels} yFormat={moneyK} height={220} />
-        </Card>
-
-        <Card eyebrow="Distribución" title="Por categoría">
-          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 20 }}>
-            <Donut
-              data={[]}
-              size={160}
-              thickness={22}
-              centerValue={kpis ? moneyK(kpis.revenue) : '—'}
-              centerLabel="total"
-            />
-          </div>
-          <div
-            style={{
-              padding: '12px 0',
-              textAlign: 'center',
-              color: 'var(--text-muted)',
-              fontFamily: 'var(--font-sans)',
-              fontSize: 'var(--text-sm)',
-            }}
-          >
-            Sin datos por categoría
-          </div>
-        </Card>
-      </div>
+        }
+      >
+        <LegendRow
+          style={{ marginBottom: 10 }}
+          items={[
+            { label: 'Actual', color: 'var(--chart-1)', line: true },
+            {
+              label: cmp === 'prev' ? 'Mes anterior' : 'Mismo mes año pasado',
+              color: 'var(--chart-compare)',
+              line: true,
+              dashed: true,
+            },
+          ]}
+        />
+        <AreaChart data={chartData} compare={chartCompare} labels={chartLabels} yFormat={moneyK} height={220} />
+      </Card>
 
       <div className="z-2col">
-        <Card eyebrow="Comparativa" title="Ingresos por día">
-          <LegendRow
-            items={[
-              { label: 'Este período', color: 'var(--chart-1)' },
-              { label: 'Período anterior', color: 'var(--chart-compare)' },
-            ]}
-            style={{ marginBottom: 14 }}
-          />
-          <GroupedBars data={dailyRows} height={200} yFormat={moneyK} />
+        <Card eyebrow="Distribución" title="Por categoría de servicio">
+          {categories.length > 0 ? (
+            <div style={{ display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap' }}>
+              <Donut
+                data={categories.map((c) => ({ value: c.revenue, color: c.color }))}
+                size={150}
+                thickness={20}
+                centerValue={catTotal ? moneyK(catTotal) : '—'}
+                centerLabel="total"
+              />
+              <div style={{ flex: 1, minWidth: 160, display: 'flex', flexDirection: 'column', gap: 10 }}>
+                {categories.map((c, i) => (
+                  <div key={i}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
+                      <span
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: 8,
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-sm)',
+                          color: 'var(--text-secondary)',
+                        }}
+                      >
+                        <span
+                          style={{
+                            width: 10,
+                            height: 10,
+                            borderRadius: 3,
+                            background: c.color,
+                            flexShrink: 0,
+                          }}
+                        />
+                        {c.name}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-sm)',
+                          fontWeight: 600,
+                          color: 'var(--text-display)',
+                        }}
+                      >
+                        {Math.round(c.pct * 100)}%
+                      </span>
+                    </div>
+                    <ProgressBar ratio={c.pct} color={c.color} height={6} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div
+              style={{
+                padding: '12px 0',
+                textAlign: 'center',
+                color: 'var(--text-muted)',
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+              }}
+            >
+              Sin datos por categoría
+            </div>
+          )}
         </Card>
 
         <Card eyebrow="Pagos" title="Métodos de pago">
@@ -231,6 +312,61 @@ const Revenue = ({ dateRange, prevDateRange }) => {
           </div>
         </Card>
       </div>
+
+      {/* Low demand services */}
+      {lowDemand.length > 0 && (
+        <Card eyebrow="Atención" title="Servicios con baja demanda">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {lowDemand.map((s, i) => (
+              <div
+                key={i}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 14,
+                  padding: '11px 14px',
+                  borderRadius: 'var(--radius-md)',
+                  background: 'var(--surface-sunken)',
+                  borderLeft: `3px solid ${LOW_TONE_COLOR[s.tone] ?? LOW_TONE_COLOR.amber}`,
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: 'var(--text-base)',
+                      fontWeight: 600,
+                      color: 'var(--text-heading)',
+                    }}
+                  >
+                    {s.name}
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: 'var(--text-xs)',
+                      color: 'var(--text-muted)',
+                      marginTop: 2,
+                    }}
+                  >
+                    {s.count} citas · {s.days_idle} días sin reserva
+                  </div>
+                </div>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-sans)',
+                    fontSize: 'var(--text-base)',
+                    fontWeight: 600,
+                    color: 'var(--text-display)',
+                  }}
+                >
+                  {money(s.revenue)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
 
       <Card eyebrow="Detalle" title="Ingresos por día">
         <DataTable

--- a/src/pages/services.jsx
+++ b/src/pages/services.jsx
@@ -5,7 +5,9 @@ import StatCard from '../components/widgets/stat-card';
 import Card from '../components/ui/card';
 import RankRow from '../components/widgets/rank-row';
 import BarChart from '../components/charts/bar-chart';
+import Donut from '../components/charts/donut';
 import DataTable from '../components/widgets/data-table';
+import Badge from '../components/ui/badge';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
@@ -14,13 +16,25 @@ const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--char
 const COLUMNS = [
   { key: 'name', label: 'Servicio' },
   { key: 'count', label: 'Citas', align: 'right' },
+  { key: 'unique', label: 'Clientas únicas', align: 'right' },
+  { key: 'repeat', label: 'Tasa de repetición', align: 'right' },
   { key: 'avg', label: 'Ticket prom.', align: 'right' },
   { key: 'rev', label: 'Ingresos', align: 'right' },
+];
+
+const CROSSSELL_COLUMNS = [
+  { key: 'service_a', label: 'Servicio A' },
+  { key: 'service_b', label: 'Servicio B' },
+  { key: 'co_purchases', label: 'Comprados juntos', align: 'right' },
+  { key: 'tag', label: 'Oportunidad', align: 'right' },
 ];
 
 const Services = ({ dateRange }) => {
   const deps = [dateRange.from_date, dateRange.to_date];
   const { data: rawTopServices } = useApi(() => api.topServices({ ...dateRange, limit: 20 }), deps);
+  const { data: categoriesData } = useApi(() => api.serviceCategories(dateRange), deps);
+  const { data: crossSellData } = useApi(() => api.crossSell(dateRange), deps);
+  const { data: repeatData } = useApi(() => api.serviceRepeatRate(dateRange), deps);
 
   const services = useMemo(
     () =>
@@ -33,6 +47,21 @@ const Services = ({ dateRange }) => {
     [rawTopServices]
   );
 
+  const repeatMap = useMemo(() => {
+    if (!repeatData?.length) return {};
+    return Object.fromEntries(repeatData.map((r) => [r.service_name, r]));
+  }, [repeatData]);
+
+  const tableRows = useMemo(
+    () =>
+      services.map((s) => ({
+        ...s,
+        unique: repeatMap[s.name]?.total_clients ?? '—',
+        repeatRate: repeatMap[s.name]?.repeat_rate ?? null,
+      })),
+    [services, repeatMap]
+  );
+
   const maxRev = services.length ? Math.max(...services.map((s) => s.rev)) : 1;
   const maxCount = services.length ? Math.max(...services.map((s) => s.count)) : 1;
   const totalCitas = services.reduce((sum, s) => sum + s.count, 0);
@@ -40,6 +69,17 @@ const Services = ({ dateRange }) => {
   const topRev = services.length ? services.reduce((a, b) => (a.rev > b.rev ? a : b)) : null;
   const topCount = services.length ? services.reduce((a, b) => (a.count > b.count ? a : b)) : null;
   const topAvg = services.length ? services.reduce((a, b) => (a.avg > b.avg ? a : b)) : null;
+
+  const categories = useMemo(() => {
+    if (!categoriesData?.length) return [];
+    return categoriesData.map((c, i) => ({
+      ...c,
+      color: `var(--chart-${(i % 5) + 1})`,
+    }));
+  }, [categoriesData]);
+  const catTotal = categories.reduce((s, c) => s + (c.revenue ?? 0), 0);
+
+  const crossSell = crossSellData ?? [];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
@@ -71,10 +111,83 @@ const Services = ({ dateRange }) => {
         />
       </div>
 
+      {/* Category breakdown donut */}
+      {categories.length > 0 && (
+        <Card eyebrow="Categorías" title="Ingresos por categoría">
+          <div style={{ display: 'flex', gap: 32, alignItems: 'center', flexWrap: 'wrap' }}>
+            <Donut
+              data={categories.map((c) => ({ value: c.revenue ?? 0, color: c.color }))}
+              size={180}
+              thickness={22}
+              centerValue={catTotal ? moneyK(catTotal) : '—'}
+              centerLabel="total"
+            />
+            <div
+              style={{
+                flex: 1,
+                minWidth: 240,
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: '10px 20px',
+              }}
+            >
+              {categories.map((c, i) => (
+                <div
+                  key={i}
+                  style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}
+                >
+                  <span
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: 'var(--text-sm)',
+                      color: 'var(--text-secondary)',
+                      minWidth: 0,
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: 3,
+                        background: c.color,
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span
+                      style={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {c.name}
+                    </span>
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-sans)',
+                      fontSize: 'var(--text-sm)',
+                      fontWeight: 600,
+                      color: 'var(--text-display)',
+                      flexShrink: 0,
+                    }}
+                  >
+                    {money(c.revenue ?? 0)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Card>
+      )}
+
       <div className="z-2col">
         <Card eyebrow="Ingresos" title="Por servicio">
           <BarChart
-            data={services.map((s, i) => ({
+            data={services.slice(0, 8).map((s, i) => ({
               label: s.name.split(' ')[0],
               value: s.rev,
               color: CHART[i % CHART.length],
@@ -86,11 +199,14 @@ const Services = ({ dateRange }) => {
 
         <Card eyebrow="Demanda" title="Citas por servicio">
           <BarChart
-            data={services.map((s, i) => ({
-              label: s.name.split(' ')[0],
-              value: s.count,
-              color: CHART[i % CHART.length],
-            }))}
+            data={[...services]
+              .sort((a, b) => b.count - a.count)
+              .slice(0, 8)
+              .map((s, i) => ({
+                label: s.name.split(' ')[0],
+                value: s.count,
+                color: CHART[i % CHART.length],
+              }))}
             height={220}
             yFormat={(v) => String(Math.round(v))}
           />
@@ -99,7 +215,7 @@ const Services = ({ dateRange }) => {
 
       <div className="z-2col">
         <Card eyebrow="Ranking" title="Por ingresos">
-          {services.map((s, i) => (
+          {services.slice(0, 6).map((s, i) => (
             <RankRow
               key={s.name}
               rank={i + 1}
@@ -107,7 +223,7 @@ const Services = ({ dateRange }) => {
               value={money(s.rev)}
               ratio={s.rev / maxRev}
               color={CHART[i % CHART.length]}
-              last={i === services.length - 1}
+              last={i === Math.min(5, services.length - 1)}
             />
           ))}
         </Card>
@@ -115,6 +231,7 @@ const Services = ({ dateRange }) => {
         <Card eyebrow="Ranking" title="Por cantidad">
           {[...services]
             .sort((a, b) => b.count - a.count)
+            .slice(0, 6)
             .map((s, i) => (
               <RankRow
                 key={s.name}
@@ -124,19 +241,62 @@ const Services = ({ dateRange }) => {
                 value={`${s.count} citas`}
                 ratio={s.count / maxCount}
                 color={CHART[i % CHART.length]}
-                last={i === services.length - 1}
+                last={i === Math.min(5, services.length - 1)}
               />
             ))}
         </Card>
       </div>
 
+      {/* Cross-sell opportunities */}
+      {crossSell.length > 0 && (
+        <Card eyebrow="Venta cruzada" title="Oportunidades de venta cruzada">
+          <DataTable
+            columns={CROSSSELL_COLUMNS}
+            rows={crossSell}
+            renderCell={(row, key) => {
+              if (key === 'service_a')
+                return <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.service_a}</span>;
+              if (key === 'service_b')
+                return <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.service_b}</span>;
+              if (key === 'co_purchases')
+                return <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{row.co_purchases}</span>;
+              if (key === 'tag')
+                return (
+                  <Badge tone="lavender" size="sm">
+                    Recomendar juntos
+                  </Badge>
+                );
+              return row[key];
+            }}
+          />
+        </Card>
+      )}
+
+      {/* Full catalogue with repeat rate */}
       <Card eyebrow="Catálogo" title="Todos los servicios">
         <DataTable
           columns={COLUMNS}
-          rows={services}
+          rows={tableRows}
           renderCell={(row, key) => {
+            if (key === 'name')
+              return <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.name}</span>;
             if (key === 'rev') return money(row.rev);
             if (key === 'avg') return money(row.avg);
+            if (key === 'unique') return row.unique ?? '—';
+            if (key === 'repeat') {
+              if (row.repeatRate == null) return '—';
+              const pct = Math.round(row.repeatRate * 100);
+              return (
+                <span
+                  style={{
+                    fontWeight: 600,
+                    color: pct >= 60 ? 'var(--positive)' : pct >= 40 ? 'var(--caution)' : 'var(--text-secondary)',
+                  }}
+                >
+                  {pct}%
+                </span>
+              );
+            }
             return row[key];
           }}
         />

--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -11,13 +11,13 @@ import DataTable from '../components/widgets/data-table';
 import Avatar from '../components/ui/avatar';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
-const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
 const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
 
 const COLUMNS = [
+  { key: 'rank', label: '#', align: 'center' },
   { key: 'name', label: 'Empleada' },
   { key: 'appts', label: 'Citas', align: 'right' },
-  { key: 'clients', label: 'Clientas', align: 'right' },
+  { key: 'recurring', label: 'Clientas recurrentes', align: 'right' },
   { key: 'avg', label: 'Ticket prom.', align: 'right' },
   { key: 'rev', label: 'Ingresos', align: 'right' },
 ];
@@ -25,6 +25,12 @@ const COLUMNS = [
 const Staff = ({ dateRange }) => {
   const deps = [dateRange.from_date, dateRange.to_date];
   const { data: staffData } = useApi(() => api.staffPerformance(dateRange), deps);
+  const { data: repeatData } = useApi(() => api.staffRepeatRate(dateRange), deps);
+
+  const repeatMap = useMemo(() => {
+    if (!repeatData?.length) return {};
+    return Object.fromEntries(repeatData.map((r) => [r.professional_id, r.repeat_clients ?? 0]));
+  }, [repeatData]);
 
   const staff = useMemo(
     () =>
@@ -36,8 +42,9 @@ const Staff = ({ dateRange }) => {
         clients: s.clients_count ?? 0,
         avg: s.avg_ticket ?? 0,
         color: CHART[i % CHART.length],
+        recurringClients: repeatMap[s.professional_id] ?? null,
       })),
-    [staffData]
+    [staffData, repeatMap]
   );
 
   const maxRev = staff.length ? Math.max(...staff.map((s) => s.rev)) : 1;
@@ -84,16 +91,31 @@ const Staff = ({ dateRange }) => {
       </div>
 
       <div className="z-2col">
-        <Card eyebrow="Distribución" title="Ingresos por empleada">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
+        <Card eyebrow="Ranking" title="Ingresos por persona">
+          {staff.map((s, i) => (
+            <RankRow
+              key={s.name}
+              rank={i + 1}
+              label={s.name}
+              sublabel={s.appts + ' citas'}
+              value={money(s.rev)}
+              ratio={s.rev / maxRev}
+              color={s.color}
+              last={i === staff.length - 1}
+            />
+          ))}
+        </Card>
+
+        <Card eyebrow="Carga" title="Distribución de trabajo">
+          <div style={{ display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap' }}>
             <Donut
-              data={staff.map((s) => ({ value: s.rev, color: s.color }))}
+              data={staff.map((s) => ({ value: s.appts, color: s.color }))}
               size={150}
               thickness={20}
-              centerValue={moneyK(totalRev)}
-              centerLabel="total"
+              centerValue={totalAppts}
+              centerLabel="citas"
             />
-            <div style={{ flex: 1, minWidth: 120 }}>
+            <div style={{ flex: 1, minWidth: 140 }}>
               {staff.map((s, i) => (
                 <div
                   key={s.name}
@@ -108,7 +130,11 @@ const Staff = ({ dateRange }) => {
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                     <span style={{ width: 10, height: 10, borderRadius: 3, background: s.color, flexShrink: 0 }} />
                     <span
-                      style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}
+                      style={{
+                        fontFamily: 'var(--font-sans)',
+                        fontSize: 'var(--text-sm)',
+                        color: 'var(--text-body)',
+                      }}
                     >
                       {s.name.split(' ')[0]}
                     </span>
@@ -121,52 +147,47 @@ const Staff = ({ dateRange }) => {
                       color: 'var(--text-heading)',
                     }}
                   >
-                    {totalRev ? `${Math.round((s.rev / totalRev) * 100)}%` : '—'}
+                    {totalAppts ? `${Math.round((s.appts / totalAppts) * 100)}%` : '—'}
                   </span>
                 </div>
               ))}
             </div>
           </div>
         </Card>
-
-        <Card eyebrow="Comparativa" title="Citas por empleada">
-          <BarChart
-            data={staff.map((s) => ({ label: s.name.split(' ')[0], value: s.appts, color: s.color }))}
-            height={200}
-            yFormat={(v) => v}
-          />
-        </Card>
       </div>
 
-      <Card eyebrow="Ranking" title="Por ingresos del mes">
-        {staff.map((s, i) => (
-          <RankRow
-            key={s.name}
-            rank={i + 1}
-            label={s.name}
-            sublabel={`${s.appts} citas · ${s.clients} clientas`}
-            value={money(s.rev)}
-            ratio={s.rev / maxRev}
-            color={s.color}
-            last={i === staff.length - 1}
-          />
-        ))}
+      <Card eyebrow="Servicios" title="Volumen por persona">
+        <BarChart
+          data={staff.map((s) => ({ label: s.name.split(' ')[0], value: s.appts, color: s.color }))}
+          height={200}
+          yFormat={(v) => String(Math.round(v))}
+        />
       </Card>
 
-      <Card eyebrow="Detalle" title="Tabla de personal">
+      <Card eyebrow="Detalle" title="Ranking del equipo">
         <DataTable
           columns={COLUMNS}
           rows={staff}
-          renderCell={(row, key) => {
+          renderCell={(row, key, ri) => {
+            if (key === 'rank')
+              return <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>{(ri ?? 0) + 1}</span>;
             if (key === 'name')
               return (
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                  <Avatar name={row.name} size="sm" />
+                  <Avatar name={row.name} size="sm" tone={ri === 0 ? 'rose' : ri === 1 ? 'lavender' : 'ink'} />
                   <span style={{ fontWeight: 'var(--fw-medium)', color: 'var(--text-heading)' }}>{row.name}</span>
                 </div>
               );
-            if (key === 'rev') return money(row.rev);
+            if (key === 'appts') return row.appts;
+            if (key === 'recurring')
+              return row.recurringClients != null ? (
+                <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{row.recurringClients}</span>
+              ) : (
+                '—'
+              );
             if (key === 'avg') return money(row.avg);
+            if (key === 'rev')
+              return <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{money(row.rev)}</span>;
             return row[key] ?? '—';
           }}
         />


### PR DESCRIPTION
## Summary

- **Login page** — centered auth card with email/password inputs, token storage in `localStorage`, error badge; auth guard in `App.js` routes to it when unauthenticated
- **Dark mode toggle** — Sun/Moon `IconButton` in topbar; `applyTheme()` persists across sessions
- **Overview** — business health scorecard (`z-health-grid`) wired to `api.healthScore()`; staff performance section upgraded to `StaffCard` grid; auto-generated insights panel
- **Revenue** — 4th KPI is now "Ingresos por cita" (revenue ÷ bookings); YoY/prev `SegmentedControl` comparison toggle; category donut from `api.serviceCategories()`; low-demand services card
- **Services** — full-width category donut at top; cross-sell opportunities table from `api.crossSell()`; "Tasa de repetición" + "Clientas únicas" columns from `api.serviceRepeatRate()`
- **Staff** — "Clientas recurrentes" column wired to `api.staffRepeatRate()`
- **Clients** — 3-tab layout: Directorio (search + loyalty donut), Retención (4 KPIs + churn table + `z-bucket-grid`), CLV & Segmentos (donut + VIP table)
- **Appointments** — 3 styled icon-background cards (Pagadas ✓ / Pendientes ⏱ / No pagadas ✗) above existing calendar layout
- **API stubs** — `post()` helper + 10 new endpoint stubs added to `api.js`; all new views gracefully show empty state when endpoint is not yet live

## Test plan

- [ ] Auth flow: open app without token → Login page; submit → token stored, redirected to dashboard; logout clears token and returns to login
- [ ] Dark mode toggle switches theme on all pages
- [ ] Overview health scorecard section appears when `GET /analytics/health-score` returns data
- [ ] Revenue page 4th KPI shows "Ingresos por cita"; YoY toggle switches chart comparison series
- [ ] Services page: category donut renders when `/analytics/service-categories` returns data; cross-sell table conditional on `/analytics/cross-sell`
- [ ] Staff ranking table includes "Clientas recurrentes" column (empty `—` when API not live)
- [ ] Clients tabs navigate correctly; bucket grid renders 5 time-range buckets
- [ ] Appointments payment-status row shows correct counts per day
- [ ] `CI=true npm run build` passes with zero warnings ✅ (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)