### PR TITLE
fix(overview): Total clientes shows clients with purchase in period

### DIFF
--- a/src/pages/overview.jsx
+++ b/src/pages/overview.jsx
@@ -161,8 +161,8 @@ const Overview = ({ dateRange, prevDateRange }) => {
         />
         <StatCard
           label="Total clientes"
-          value={kpis ? kpis.new_clients.toLocaleString('es-MX') : '—'}
-          caption="en base de datos"
+          value={kpis ? kpis.distinct_clients.toLocaleString('es-MX') : '—'}
+          caption="clientas con compra en el periodo"
           icon="Heart"
           spark={[]}
           sparkColor="var(--chart-4)"


### PR DESCRIPTION
## Problem
The "Total clientes" card on Resumen General displayed `kpis.new_clients` (clients *created* in the period — e.g. 18) which doesn't match its label.

## Fix
Use `kpis.distinct_clients` (clients with at least one purchase in the selected period) and update the caption to "clientas con compra en el periodo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)