### PR TITLE
feat(clients): sortable columns in Retención table

### DIFF
--- a/src/components/widgets/data-table.jsx
+++ b/src/components/widgets/data-table.jsx
@@ -1,54 +1,113 @@
-const DataTable = ({ columns = [], rows = [], renderCell, style }) => (
-  <div style={{ overflowX: 'auto', ...style }}>
-    <table
-      style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)' }}
-    >
-      <thead>
-        <tr>
-          {columns.map((col) => (
-            <th
-              key={col.key}
-              style={{
-                textAlign: col.align || 'left',
-                padding: '8px 12px',
-                fontSize: 'var(--text-xs)',
-                fontWeight: 'var(--fw-semibold)',
-                letterSpacing: 'var(--ls-label)',
-                textTransform: 'uppercase',
-                color: 'var(--text-muted)',
-                borderBottom: '1px solid var(--border-subtle)',
-                whiteSpace: col.nowrap ? 'nowrap' : undefined,
-                background: 'var(--surface-sunken)',
-              }}
-            >
-              {col.label}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, rowIndex) => (
-          <tr key={rowIndex} className="z-row">
+import { useState, useMemo } from 'react';
+
+const SortArrows = ({ dir }) => (
+  <span
+    aria-hidden
+    style={{
+      display: 'inline-flex',
+      flexDirection: 'column',
+      lineHeight: 0,
+      marginLeft: 5,
+      verticalAlign: 'middle',
+      fontSize: 8,
+    }}
+  >
+    <span style={{ color: dir === 'asc' ? 'var(--text-brand)' : 'var(--border-strong)' }}>▲</span>
+    <span style={{ color: dir === 'desc' ? 'var(--text-brand)' : 'var(--border-strong)' }}>▼</span>
+  </span>
+);
+
+const DataTable = ({ columns = [], rows = [], renderCell, style }) => {
+  const [sort, setSort] = useState(null); // { key, dir: 'asc' | 'desc' }
+
+  const handleHeaderClick = (col) => {
+    if (!col.sortable) return;
+    setSort((prev) => {
+      if (prev?.key !== col.key) return { key: col.key, dir: 'desc' };
+      if (prev.dir === 'desc') return { key: col.key, dir: 'asc' };
+      return null; // third click restores original order
+    });
+  };
+
+  const sortedRows = useMemo(() => {
+    if (!sort) return rows;
+    const col = columns.find((c) => c.key === sort.key);
+    if (!col) return rows;
+    const getValue = col.sortValue ?? ((row) => row[col.key]);
+    const factor = sort.dir === 'asc' ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      const va = getValue(a);
+      const vb = getValue(b);
+      if (va == null && vb == null) return 0;
+      if (va == null) return 1; // nulls always last
+      if (vb == null) return -1;
+      if (typeof va === 'string' || typeof vb === 'string') return String(va).localeCompare(String(vb), 'es') * factor;
+      return (va - vb) * factor;
+    });
+  }, [rows, columns, sort]);
+
+  return (
+    <div style={{ overflowX: 'auto', ...style }}>
+      <table
+        style={{
+          width: '100%',
+          borderCollapse: 'collapse',
+          fontFamily: 'var(--font-sans)',
+          fontSize: 'var(--text-sm)',
+        }}
+      >
+        <thead>
+          <tr>
             {columns.map((col) => (
-              <td
+              <th
                 key={col.key}
+                onClick={() => handleHeaderClick(col)}
+                title={col.sortable ? 'Ordenar' : undefined}
                 style={{
                   textAlign: col.align || 'left',
-                  padding: '10px 12px',
-                  borderBottom: rowIndex < rows.length - 1 ? '1px solid var(--border-subtle)' : 'none',
-                  color: 'var(--text-body)',
+                  padding: '8px 12px',
+                  fontSize: 'var(--text-xs)',
+                  fontWeight: 'var(--fw-semibold)',
+                  letterSpacing: 'var(--ls-label)',
+                  textTransform: 'uppercase',
+                  color: sort?.key === col.key ? 'var(--text-brand)' : 'var(--text-muted)',
+                  borderBottom: '1px solid var(--border-subtle)',
                   whiteSpace: col.nowrap ? 'nowrap' : undefined,
-                  verticalAlign: 'middle',
+                  background: 'var(--surface-sunken)',
+                  cursor: col.sortable ? 'pointer' : undefined,
+                  userSelect: col.sortable ? 'none' : undefined,
                 }}
               >
-                {renderCell ? renderCell(row, col.key, rowIndex) : row[col.key]}
-              </td>
+                {col.label}
+                {col.sortable && <SortArrows dir={sort?.key === col.key ? sort.dir : null} />}
+              </th>
             ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
-  </div>
-);
+        </thead>
+        <tbody>
+          {sortedRows.map((row, rowIndex) => (
+            <tr key={rowIndex} className="z-row">
+              {columns.map((col) => (
+                <td
+                  key={col.key}
+                  style={{
+                    textAlign: col.align || 'left',
+                    padding: '10px 12px',
+                    borderBottom: rowIndex < sortedRows.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+                    color: 'var(--text-body)',
+                    whiteSpace: col.nowrap ? 'nowrap' : undefined,
+                    verticalAlign: 'middle',
+                  }}
+                >
+                  {renderCell ? renderCell(row, col.key, rowIndex) : row[col.key]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
 
 export default DataTable;

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -20,14 +20,39 @@ const TABS = [
   { value: 'clv', label: 'CLV & Segmentos' },
 ];
 
+const ESTADO_RANK = { active: 0, activa: 0, at_risk: 1, en_riesgo: 1, churned: 2, perdida: 2, lost: 2 };
+
 const RETENTION_COLS = [
   { key: 'name', label: 'Clienta' },
   { key: 'last_visit', label: 'Última visita' },
-  { key: 'days_since', label: 'Días sin visitar', align: 'right' },
+  {
+    key: 'days_since',
+    label: 'Días sin visitar',
+    align: 'right',
+    sortable: true,
+    sortValue: (row) => row.days_since_last,
+  },
   { key: 'avg_frequency', label: 'Frecuencia' },
-  { key: 'churn_status', label: 'Estado' },
-  { key: 'lifetime_revenue', label: 'Ingresos totales', align: 'right' },
-  { key: 'estimated_lost', label: 'Ingreso perdido', align: 'right' },
+  {
+    key: 'churn_status',
+    label: 'Estado',
+    sortable: true,
+    sortValue: (row) => ESTADO_RANK[row.churn_status] ?? 3,
+  },
+  {
+    key: 'lifetime_revenue',
+    label: 'Ingresos totales',
+    align: 'right',
+    sortable: true,
+    sortValue: (row) => row.lifetime_revenue ?? 0,
+  },
+  {
+    key: 'estimated_lost',
+    label: 'Ingreso perdido',
+    align: 'right',
+    sortable: true,
+    sortValue: (row) => row.estimated_lost,
+  },
 ];
 
 const VIP_COLS = [


### PR DESCRIPTION
## What
Adds column sorting to the "Clasificación de clientas" table on Clientas → Retención:

- **Días sin visitar** — sortable asc/desc
- **Estado** — sorts by severity rank (Activa → En riesgo → Perdida)
- **Ingresos totales** — sortable asc/desc
- **Ingreso perdido** — sortable asc/desc; clients without estimated loss always sort last

## How
`DataTable` gains opt-in `sortable`/`sortValue` per column (no changes for existing tables). Clicking a header cycles **desc → asc → original order**, with ▲▼ indicators highlighting the active direction.

## Test plan
- [ ] Click "Días sin visitar" → highest first; click again → lowest first; third click → original order
- [ ] "Estado" groups Activa/En riesgo/Perdida correctly in both directions
- [ ] "Ingreso perdido": clients with "—" stay at the bottom in both directions
- [ ] Other tables (Directorio, VIP, Servicios) render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)