### PR TITLE
feat(clients): metric explanation tooltips on Clientas page

### DIFF
--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
+import InfoTip from './info-tip';
 
-const Card = ({ title, eyebrow, action, children, padding = 20, interactive = false, style }) => {
+const Card = ({ title, eyebrow, action, info, children, padding = 20, interactive = false, style }) => {
   const [hovered, setHovered] = useState(false);
 
   return (
@@ -55,6 +56,7 @@ const Card = ({ title, eyebrow, action, children, padding = 20, interactive = fa
                 }}
               >
                 {title}
+                {info && <InfoTip text={info} />}
               </div>
             )}
           </div>

--- a/src/components/ui/info-tip.jsx
+++ b/src/components/ui/info-tip.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+
+/**
+ * Small ⓘ icon that reveals an explanation on hover, keyboard focus, or tap.
+ * Usage: <InfoTip text="Qué significa este número" />
+ */
+const InfoTip = ({ text, align = 'left' }) => {
+  const [open, setOpen] = useState(false);
+
+  if (!text) return null;
+
+  return (
+    <span
+      style={{ position: 'relative', display: 'inline-flex', verticalAlign: 'middle', marginLeft: 6 }}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      <button
+        type="button"
+        aria-label={text}
+        onClick={() => setOpen((v) => !v)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        style={{
+          all: 'unset',
+          cursor: 'help',
+          width: 15,
+          height: 15,
+          borderRadius: '50%',
+          border: '1px solid var(--border-strong)',
+          color: 'var(--text-muted)',
+          fontSize: 10,
+          fontWeight: 600,
+          fontFamily: 'var(--font-sans)',
+          fontStyle: 'italic',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          lineHeight: 1,
+        }}
+      >
+        i
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 8px)',
+            [align === 'right' ? 'right' : 'left']: -8,
+            zIndex: 50,
+            width: 230,
+            padding: '10px 12px',
+            background: 'var(--text-heading)',
+            color: 'var(--surface-card)',
+            borderRadius: 'var(--radius-sm)',
+            boxShadow: 'var(--shadow-md)',
+            fontFamily: 'var(--font-sans)',
+            fontSize: 'var(--text-xs)',
+            fontWeight: 400,
+            fontStyle: 'normal',
+            letterSpacing: 'normal',
+            textTransform: 'none',
+            lineHeight: 1.5,
+            whiteSpace: 'normal',
+          }}
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  );
+};
+
+export default InfoTip;

--- a/src/components/widgets/stat-card.jsx
+++ b/src/components/widgets/stat-card.jsx
@@ -1,5 +1,6 @@
 import DeltaBadge from '../ui/delta-badge';
 import Sparkline from '../charts/sparkline';
+import InfoTip from '../ui/info-tip';
 import { getIcon } from '../../lib/icons';
 
 const StatCard = ({
@@ -9,6 +10,7 @@ const StatCard = ({
   deltaFormat = 'percent',
   caption,
   icon,
+  info,
   spark,
   sparkColor = 'var(--chart-1)',
   numeralStyle = 'display',
@@ -43,6 +45,7 @@ const StatCard = ({
           }}
         >
           {label}
+          {info && <InfoTip text={info} />}
         </span>
         {Icon && (
           <span

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -9,6 +9,7 @@ import DataTable from '../components/widgets/data-table';
 import Avatar from '../components/ui/avatar';
 import Badge from '../components/ui/badge';
 import SegmentedControl from '../components/ui/segmented-control';
+import InfoTip from '../components/ui/info-tip';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const moneyK = (v) => (v >= 1000 ? '$' + (v / 1000).toFixed(1) + 'k' : '$' + Math.round(v));
@@ -165,6 +166,7 @@ const Clients = ({ dateRange }) => {
               value={(kpis?.distinct_clients ?? 0).toLocaleString('es-MX')}
               caption="activas en el periodo"
               icon="Users"
+              info="Clientas con al menos una compra en el periodo seleccionado. No incluye clientas registradas que nunca han comprado (esas aparecen abajo en el directorio)."
               spark={[]}
               sparkColor="var(--chart-1)"
             />
@@ -173,23 +175,30 @@ const Clients = ({ dateRange }) => {
               value={stats ? stats.vip_count.toLocaleString('es-MX') : '—'}
               caption="4+ visitas históricas"
               icon="Star"
+              info="Clientas con 4 o más compras en toda su historia. Este número no cambia con el periodo seleccionado."
             />
             <StatCard
               label="Retención"
               value={retention ? pct(retention.retention_rate) : '—'}
               caption="clientas que regresaron"
               icon="TrendingUp"
+              info="De las clientas que compraron en el periodo anterior (mismo número de días), porcentaje que volvió a comprar en este periodo."
             />
             <StatCard
               label="Ticket promedio"
               value={kpis ? '$' + Math.round(kpis.avg_ticket).toLocaleString('es-MX') : '—'}
               caption="este periodo"
               icon="DollarSign"
+              info="Ingresos del periodo divididos entre el número de ventas. Es el gasto promedio por visita."
             />
           </div>
 
           <div className="z-2col">
-            <Card eyebrow="Segmentación" title="Lealtad de clientas">
+            <Card
+              eyebrow="Segmentación"
+              title="Lealtad de clientas"
+              info="Nuevas: clientas registradas durante el periodo. Recurrentes: clientas que compraron en el periodo y ya habían comprado antes. El centro muestra el total de clientas activas del periodo."
+            >
               <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
                 <Donut
                   data={donutData}
@@ -232,7 +241,11 @@ const Clients = ({ dateRange }) => {
               </div>
             </Card>
 
-            <Card eyebrow="Frecuencia" title="Visitas por clienta">
+            <Card
+              eyebrow="Frecuencia"
+              title="Visitas por clienta"
+              info="Distribución de las clientas que compraron en el periodo, según cuántas visitas hicieron dentro del mismo periodo."
+            >
               {visitsData.length > 0 ? (
                 <BarChart data={visitsData} height={200} yFormat={(v) => v} />
               ) : (
@@ -256,6 +269,7 @@ const Clients = ({ dateRange }) => {
           <Card
             eyebrow="Directorio"
             title="Clientes"
+            info="Todas las clientas registradas en AgendaPro, hayan comprado o no. Este directorio no depende del periodo seleccionado. Se muestran hasta 100 resultados; usa el buscador para encontrar a alguien."
             action={
               <input
                 placeholder="Buscar..."
@@ -321,6 +335,7 @@ const Clients = ({ dateRange }) => {
               value={String(retentionKpis.enRiesgo)}
               caption="clientas"
               icon="AlertTriangle"
+              info="Clientas cuya última compra fue hace 45 a 89 días. Todavía es buen momento para invitarlas a regresar."
               numeralStyle="sans"
             />
             <StatCard
@@ -328,6 +343,7 @@ const Clients = ({ dateRange }) => {
               value={String(retentionKpis.perdidas)}
               caption="sin volver +90d"
               icon="UserX"
+              info="Clientas cuya última compra fue hace 90 días o más. Se consideran perdidas mientras no vuelvan a comprar."
               numeralStyle="sans"
             />
             <StatCard
@@ -335,6 +351,7 @@ const Clients = ({ dateRange }) => {
               value={String(retentionKpis.reactivadas)}
               caption="este mes"
               icon="UserCheck"
+              info="Clientas que estaban perdidas (90+ días sin venir) y volvieron a comprar en este periodo."
               numeralStyle="sans"
             />
             <StatCard
@@ -342,11 +359,16 @@ const Clients = ({ dateRange }) => {
               value={retentionKpis.retencionPct != null ? pct(retentionKpis.retencionPct) : '—'}
               caption="vs mes anterior"
               icon="Repeat"
+              info="De las clientas que compraron en el periodo anterior, porcentaje que volvió a comprar en este periodo."
               numeralStyle="sans"
             />
           </div>
 
-          <Card eyebrow="Riesgo de fuga" title="Clasificación de clientas">
+          <Card
+            eyebrow="Riesgo de fuga"
+            title="Clasificación de clientas"
+            info="Toda clienta que ha comprado alguna vez, clasificada por su última visita: Activa (menos de 45 días), En riesgo (45–89) o Perdida (90+). Ingreso perdido estima cuánto dejó de gastar según su ticket promedio y el tiempo ausente. Haz clic en los encabezados para ordenar."
+          >
             {retentionProfiles.length > 0 ? (
               <DataTable
                 columns={RETENTION_COLS}
@@ -417,6 +439,7 @@ const Clients = ({ dateRange }) => {
               }}
             >
               Tiempo sin regresar
+              <InfoTip text="Cuántas clientas llevan más de 30, 60, 90, 180 o 365 días sin comprar. Cada clienta cuenta en todos los rangos que supera: una con 100 días aparece en +30, +60 y +90." />
             </div>
             <div className="z-bucket-grid">
               {churnBuckets.map((b, i) => (
@@ -452,7 +475,11 @@ const Clients = ({ dateRange }) => {
       {/* ── CLV & SEGMENTOS TAB ── */}
       {tab === 'clv' && (
         <>
-          <Card eyebrow="Valor" title="Ingresos por segmento">
+          <Card
+            eyebrow="Valor"
+            title="Ingresos por segmento"
+            info="Ingresos históricos totales agrupados por tipo de clienta. VIP: $3,000+ y 6+ visitas. Leal: $1,200+ y 3+ visitas. En riesgo: 45–89 días sin venir. Perdida: 90+ días. Ocasional: el resto."
+          >
             {clvSegments.length > 0 ? (
               <div style={{ display: 'flex', gap: 32, alignItems: 'center', flexWrap: 'wrap' }}>
                 <Donut
@@ -536,7 +563,11 @@ const Clients = ({ dateRange }) => {
             )}
           </Card>
 
-          <Card eyebrow="Valor de vida" title="Top 10 clientas VIP">
+          <Card
+            eyebrow="Valor de vida"
+            title="Top 10 clientas VIP"
+            info="Las 10 clientas con mayores ingresos históricos. Ingresos totales suma todas sus compras desde su primera visita; el ticket promedio es su gasto típico por visita."
+          >
             {vipClients.length > 0 ? (
               <DataTable
                 columns={VIP_COLS}


### PR DESCRIPTION
## Problem
It's hard to know what each number on Clientas means — e.g. why "Total clientes" (88) differs from AgendaPro's directory count (557), or what makes a clienta "En riesgo".

## Solution
New reusable `InfoTip` component: an ⓘ icon next to each stat, chart and table title. Hover, keyboard focus, or tap reveals a plain-Spanish explanation of how the number is computed and whether it depends on the selected date range.

`StatCard` and `Card` gain an optional `info` prop (no changes where unused), so the pattern can extend to other pages later.

## Coverage (13 tooltips)
- **Directorio**: Total clientes, Clientas VIP, Retención, Ticket promedio, Lealtad donut, Visitas por clienta, Directorio table
- **Retención**: En riesgo, Perdidas, Reactivadas, Retención, Clasificación table (incl. thresholds 45/90 días + Ingreso perdido formula), Tiempo sin regresar buckets
- **CLV**: Ingresos por segmento (segment criteria), Top 10 VIP

## Test plan
- [ ] Hover each ⓘ on the three sub-tabs → tooltip appears above the icon
- [ ] Tab-focus an ⓘ with keyboard → tooltip shows; blur hides it
- [ ] Tap on touch devices toggles the tooltip
- [ ] Pages not using `info` render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)