### PR TITLE
feat(app): Zenya isotipo as favicon and real tab title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" type="image/png" href="%PUBLIC_URL%/zenya-mark-rose.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#9e4d6b" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Zenya Nails & Spa — dashboard de gestión"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/zenya-mark-rose.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Zenya Nails & Spa</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,25 +1,15 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Zenya",
+  "name": "Zenya Nails & Spa",
   "icons": [
     {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
+      "src": "zenya-mark-rose.png",
       "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
+      "sizes": "147x158"
     }
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#9e4d6b",
+  "background_color": "#fcfaf8"
 }


### PR DESCRIPTION
## What
- Browser tab icon: React default → **Zenya isotipo** (`zenya-mark-rose.png`, already in `public/`)
- Tab title: "React App" → **"Zenya Nails & Spa"**
- `apple-touch-icon` → Zenya mark (home-screen shortcut on iOS)
- `manifest.json`: name/short_name → Zenya, icon → mark, theme `#9e4d6b` (brand rose) / background `#fcfaf8` (cream)
- Meta description updated

## Test plan
- [ ] Hard-refresh localhost:3000 → tab shows the Zenya mark and "Zenya Nails & Spa" (favicons cache aggressively; may need Cmd+Shift+R)
- [ ] After stage deploy, stage.zenya.com.mx tab shows the mark

🤖 Generated with [Claude Code](https://claude.com/claude-code)