### PR TITLE
feat(staff): ¿Quién atendió? breakdown for Cosmetología and Lashes y Cejas

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -49,6 +49,7 @@ export const api = {
   serviceRepeatRate: (params) => get('/analytics/service-repeat-rate', params),
   staffRepeatRate: (params) => get('/analytics/staff-repeat-rate', params),
   unassignedServices: (params) => get('/analytics/unassigned-services', params),
+  sharedProviderBreakdown: (params) => get('/analytics/shared-provider-breakdown', params),
   clientProfiles: (params) => get('/analytics/client-profiles', params),
   clvSegments: (params) => get('/analytics/clv-segments', params),
   lowDemandServices: (params) => get('/analytics/low-demand-services', params),

--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -34,6 +34,7 @@ const Staff = ({ dateRange }) => {
   const { data: staffData } = useApi(() => api.staffPerformance(dateRange), deps);
   const { data: repeatData } = useApi(() => api.staffRepeatRate(dateRange), deps);
   const { data: unassigned } = useApi(() => api.unassignedServices(dateRange), deps);
+  const { data: sharedBreakdown } = useApi(() => api.sharedProviderBreakdown(dateRange), deps);
 
   const repeatMap = useMemo(() => {
     if (!repeatData?.length) return {};
@@ -174,6 +175,37 @@ const Staff = ({ dateRange }) => {
           </div>
         </Card>
       </div>
+
+      {(sharedBreakdown ?? []).some((g) => g.total_count > 0) && (
+        <div className="z-2col">
+          {(sharedBreakdown ?? [])
+            .filter((g) => g.total_count > 0)
+            .map((group) => {
+              const maxPersonRev = Math.max(...group.people.map((p) => p.revenue), 1);
+              return (
+                <Card
+                  key={group.provider_id}
+                  eyebrow="¿Quién atendió?"
+                  title={group.category}
+                  info="Estas cuentas las comparten varias personas; quién atendió se identifica por el nombre escrito en la nota de la cita (ej. 'Atiende Chio'). Los servicios cuya nota no menciona a nadie conocido quedan como No asignados."
+                >
+                  {group.people.map((p, i) => (
+                    <RankRow
+                      key={p.name}
+                      rank={i + 1}
+                      label={p.name}
+                      sublabel={p.count + ' servicios'}
+                      value={money(p.revenue)}
+                      ratio={p.revenue / maxPersonRev}
+                      color={p.name === 'No asignados' ? 'var(--chart-compare)' : CHART[i % CHART.length]}
+                      last={i === group.people.length - 1}
+                    />
+                  ))}
+                </Card>
+              );
+            })}
+        </div>
+      )}
 
       <Card eyebrow="Servicios" title="Volumen por persona">
         <BarChart


### PR DESCRIPTION
## What
New **"¿Quién atendió?"** section on the Personal page — two cards (Cosmetología, Lashes y Cejas) ranking the people who actually performed the services under those shared accounts, with revenue and service counts:

- **Lashes y Cejas** → Rocío, Abi
- **Cosmetología** → Dulce, Fati, Eli, Bety
- Unmatched notes → gray **"No asignados"** bucket inside each category

Attribution comes from the booking note ("Atiende Chio", "Atendi yo", …) via the new `/analytics/shared-provider-breakdown` endpoint. Each card has an ⓘ tooltip explaining the notes-based attribution. Cards only render when there's data in the period.

## Depends on
zenya-api PR #19 — merge first.

## Verified (Mar–Jun, localhost)
- Lashes y Cejas: Rocío $7,220 · Abi $6,300 · No asignados $5,685
- Cosmetología: Eli $6,090 · Dulce $5,534 · Bety $3,283 · Fati $2,986 · No asignados $4,158

🤖 Generated with [Claude Code](https://claude.com/claude-code)