### PR TITLE
fix: persist synced appointment reminders across reloads

### DIFF
--- a/src/components/widgets/appointment-reminders.jsx
+++ b/src/components/widgets/appointment-reminders.jsx
@@ -85,6 +85,8 @@ const EmptyState = ({ text }) => (
   </div>
 );
 
+const STORAGE_KEY = 'zenya.appointmentReminders.lastSync';
+
 const REMINDER_COLS = [
   { key: 'name', label: 'Clienta' },
   { key: 'phone', label: 'Teléfono' },
@@ -117,6 +119,27 @@ const AppointmentReminders = () => {
   useEffect(() => {
     loadTemplate();
   }, []);
+
+  // Restore the last sync from this browser so a page reload doesn't wipe the
+  // list — "ya enviado" status still comes fresh from the server either way,
+  // this just saves having to click "Sincronizar" again to see it.
+  useEffect(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
+      if (saved?.clients?.length) {
+        setTargetDate(saved.targetDate);
+        setClients(saved.clients);
+        setSynced(true);
+      }
+    } catch {
+      // ignore malformed/unavailable storage
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!synced) return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ targetDate, clients }));
+  }, [synced, targetDate, clients]);
 
   const handleSaveTemplate = async () => {
     setSavingTemplate(true);


### PR DESCRIPTION
## Summary
The synced "citas de mañana" client list only lived in React component state. A page reload wiped it back to the empty pre-sync view, even though nothing changed server-side — the "already sent" status is always computed fresh from `whatsapp_sends`, it just required clicking "Sincronizar" again to see it. Now cached in `localStorage` and restored on mount.

## Test plan
- [x] `npm run lint` clean.
- [ ] Manual verification pending on stage after deploy: sync, reload, confirm list persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)