### PR TITLE
feat: A/B test buttons for the reminder template — Web vs. App

### DIFF
--- a/src/components/widgets/appointment-reminders.jsx
+++ b/src/components/widgets/appointment-reminders.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
-import { RefreshCw, Send } from 'lucide-react';
+import { RefreshCw, Send, Smartphone } from 'lucide-react';
 import { api } from '../../lib/api';
-import { buildWhatsappUrl } from '../../lib/whatsapp';
+import { buildWhatsappUrl, buildWhatsappAppUrl, TEST_RECIPIENTS } from '../../lib/whatsapp';
 import Card from '../ui/card';
 import Badge from '../ui/badge';
 import Button from '../ui/button';
@@ -85,6 +85,13 @@ const EmptyState = ({ text }) => (
   </div>
 );
 
+function sampleDetalleCita() {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const dateStr = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`;
+  return buildDetalleCita([{ time: '12:00', service_name: 'Manicure de prueba' }], dateStr);
+}
+
 const STORAGE_KEY = 'zenya.appointmentReminders.lastSync';
 
 const REMINDER_COLS = [
@@ -107,6 +114,14 @@ const AppointmentReminders = () => {
   const [targetDate, setTargetDate] = useState(null);
   const [clients, setClients] = useState([]);
   const [syncMessage, setSyncMessage] = useState(null); // { type: 'info' | 'error', text }
+  const [testRecipient, setTestRecipient] = useState(TEST_RECIPIENTS[0].phone);
+
+  const handleTestSend = (urlBuilder) => {
+    if (!template) return;
+    const recipient = TEST_RECIPIENTS.find((r) => r.phone === testRecipient) ?? TEST_RECIPIENTS[0];
+    const message = fillReminderTemplate(template.body, sampleDetalleCita(), recipient.name);
+    window.open(urlBuilder(recipient.phone, message), '_blank', 'noopener');
+  };
 
   const loadTemplate = async () => {
     const found = await api.whatsappTemplates({ category: 'reminder' });
@@ -218,19 +233,50 @@ const AppointmentReminders = () => {
       <Card
         eyebrow="WhatsApp"
         title="Plantilla de recordatorio"
-        info="Se manda la noche antes de la cita. Usa {detalle_cita} para el bloque de fecha/hora/servicio (se genera solo, incluyendo todas las citas si la clienta tiene más de una) y {nombre} para su primer nombre."
+        info="Se manda la noche antes de la cita. Usa {detalle_cita} para el bloque de fecha/hora/servicio (se genera solo, incluyendo todas las citas si la clienta tiene más de una) y {nombre} para su primer nombre. Los botones de prueba mandan un mensaje de ejemplo a Bety o Carlos, uno abriendo Web y otro la app — para comparar si la app respeta los emojis antes de confiar en ella."
         action={
           !editing && (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={async () => {
-                if (!templateLoaded) await loadTemplate();
-                setEditing(true);
-              }}
-            >
-              {template ? 'Editar' : 'Crear plantilla'}
-            </Button>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              {template && (
+                <>
+                  <select
+                    value={testRecipient}
+                    onChange={(e) => setTestRecipient(e.target.value)}
+                    style={{ ...inputStyle, padding: '4px 8px', height: 30, fontSize: 'var(--text-xs)' }}
+                  >
+                    {TEST_RECIPIENTS.map((r) => (
+                      <option key={r.phone} value={r.phone}>
+                        {r.name}
+                      </option>
+                    ))}
+                  </select>
+                  <IconButton
+                    icon={Send}
+                    size="sm"
+                    variant="outline"
+                    title="Probar por Web (web.whatsapp.com)"
+                    onClick={() => handleTestSend(buildWhatsappUrl)}
+                  />
+                  <IconButton
+                    icon={Smartphone}
+                    size="sm"
+                    variant="outline"
+                    title="Probar por la app de WhatsApp (wa.me)"
+                    onClick={() => handleTestSend(buildWhatsappAppUrl)}
+                  />
+                </>
+              )}
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={async () => {
+                  if (!templateLoaded) await loadTemplate();
+                  setEditing(true);
+                }}
+              >
+                {template ? 'Editar' : 'Crear plantilla'}
+              </Button>
+            </div>
           )
         }
       >

--- a/src/components/widgets/reactivation-panel.jsx
+++ b/src/components/widgets/reactivation-panel.jsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 import { MessageCircle, Plus, Edit2, Archive, Send } from 'lucide-react';
 import { api } from '../../lib/api';
 import { useApi } from '../../hooks/use-api';
-import { buildWhatsappUrl } from '../../lib/whatsapp';
+import { buildWhatsappUrl, TEST_RECIPIENTS } from '../../lib/whatsapp';
 import Card from '../ui/card';
 import Badge from '../ui/badge';
 import Button from '../ui/button';
@@ -27,11 +27,6 @@ function fillTemplate(body, firstName) {
   const name = (firstName || '').trim().split(/\s+/)[0] || 'hola';
   return (body || '').replaceAll('{nombre}', name);
 }
-
-const TEST_RECIPIENTS = [
-  { name: 'Bety', phone: '522224714697' },
-  { name: 'Carlos', phone: '522222063234' },
-];
 
 function fmtDate(iso) {
   if (!iso) return '';

--- a/src/lib/whatsapp.js
+++ b/src/lib/whatsapp.js
@@ -2,10 +2,23 @@ export function digitsOnly(phone) {
   return (phone || '').replace(/\D/g, '');
 }
 
-// web.whatsapp.com (rather than wa.me) so this reliably opens in Chrome —
-// wa.me/api.whatsapp.com short links get intercepted by the WhatsApp
-// Desktop app on macOS/Windows when it's installed, and that app's own
-// emoji rendering is known to be unreliable.
+// web.whatsapp.com (rather than wa.me) so this reliably opens in Chrome.
+// wa.me/api.whatsapp.com short links can get intercepted by the WhatsApp
+// Desktop app on macOS/Windows when it's installed — whether that app
+// renders emoji correctly depends on which build is installed, so this is
+// the default until confirmed otherwise via buildWhatsappAppUrl below.
 export function buildWhatsappUrl(phone, message) {
   return `https://web.whatsapp.com/send?phone=${digitsOnly(phone)}&text=${encodeURIComponent(message)}`;
 }
+
+// wa.me — for deliberately testing/using the WhatsApp Desktop app instead of
+// the browser. Only wire this up somewhere real once a test message through
+// it has been visually confirmed to render emoji correctly.
+export function buildWhatsappAppUrl(phone, message) {
+  return `https://wa.me/${digitsOnly(phone)}?text=${encodeURIComponent(message)}`;
+}
+
+export const TEST_RECIPIENTS = [
+  { name: 'Bety', phone: '522224714697' },
+  { name: 'Carlos', phone: '522222063234' },
+];


### PR DESCRIPTION
## Summary
Adds "Probar por Web" (web.whatsapp.com) and "Probar por la app" (wa.me) buttons next to the reminder template, sending a sample message to Bety or Carlos — so the app-vs-browser emoji rendering question can be answered by actually looking at the result on a real WhatsApp Desktop install, instead of guessing.

wa.me is **not** wired into any real reminder-sending flow yet — this is purely a manual comparison tool. If the app is confirmed to render emoji correctly, a follow-up PR will add the real Web/App choice to the send button.

Also moves `TEST_RECIPIENTS` into `lib/whatsapp.js` so `reactivation-panel.jsx` and `appointment-reminders.jsx` share one list instead of duplicating it.

## Test plan
- [x] `npm run lint` and `npm run build` both clean.
- [ ] Manual: click both test buttons on stage, confirm emoji rendering in each destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)