### PR TITLE
chore: remove broken WhatsApp-app test button

### DIFF
--- a/src/components/widgets/appointment-reminders.jsx
+++ b/src/components/widgets/appointment-reminders.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
-import { RefreshCw, Send, Smartphone } from 'lucide-react';
+import { RefreshCw, Send } from 'lucide-react';
 import { api } from '../../lib/api';
-import { buildWhatsappUrl, buildWhatsappAppUrl, TEST_RECIPIENTS } from '../../lib/whatsapp';
+import { buildWhatsappUrl, TEST_RECIPIENTS } from '../../lib/whatsapp';
 import Card from '../ui/card';
 import Badge from '../ui/badge';
 import Button from '../ui/button';
@@ -233,7 +233,7 @@ const AppointmentReminders = () => {
       <Card
         eyebrow="WhatsApp"
         title="Plantilla de recordatorio"
-        info="Se manda la noche antes de la cita. Usa {detalle_cita} para el bloque de fecha/hora/servicio (se genera solo, incluyendo todas las citas si la clienta tiene más de una) y {nombre} para su primer nombre. Los botones de prueba mandan un mensaje de ejemplo a Bety o Carlos, uno abriendo Web y otro la app — para comparar si la app respeta los emojis antes de confiar en ella."
+        info="Se manda la noche antes de la cita. Usa {detalle_cita} para el bloque de fecha/hora/servicio (se genera solo, incluyendo todas las citas si la clienta tiene más de una) y {nombre} para su primer nombre. El botón de prueba manda un mensaje de ejemplo a Bety o Carlos por WhatsApp Web para revisar cómo se ve antes de mandarlo de verdad."
         action={
           !editing && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -254,15 +254,8 @@ const AppointmentReminders = () => {
                     icon={Send}
                     size="sm"
                     variant="outline"
-                    title="Probar por Web (web.whatsapp.com)"
+                    title="Enviar mensaje de prueba"
                     onClick={() => handleTestSend(buildWhatsappUrl)}
-                  />
-                  <IconButton
-                    icon={Smartphone}
-                    size="sm"
-                    variant="outline"
-                    title="Probar por la app de WhatsApp (wa.me)"
-                    onClick={() => handleTestSend(buildWhatsappAppUrl)}
                   />
                 </>
               )}

--- a/src/lib/whatsapp.js
+++ b/src/lib/whatsapp.js
@@ -3,19 +3,13 @@ export function digitsOnly(phone) {
 }
 
 // web.whatsapp.com (rather than wa.me) so this reliably opens in Chrome.
-// wa.me/api.whatsapp.com short links can get intercepted by the WhatsApp
-// Desktop app on macOS/Windows when it's installed — whether that app
-// renders emoji correctly depends on which build is installed, so this is
-// the default until confirmed otherwise via buildWhatsappAppUrl below.
+// wa.me/api.whatsapp.com short links get intercepted by the WhatsApp Desktop
+// app on macOS when it's installed, and that app has a confirmed encoding
+// bug that corrupts emoji in the text= parameter (verified: every emoji in a
+// test message came through as U+FFFD replacement characters). Don't use
+// wa.me for anything real until Meta fixes it on their end.
 export function buildWhatsappUrl(phone, message) {
   return `https://web.whatsapp.com/send?phone=${digitsOnly(phone)}&text=${encodeURIComponent(message)}`;
-}
-
-// wa.me — for deliberately testing/using the WhatsApp Desktop app instead of
-// the browser. Only wire this up somewhere real once a test message through
-// it has been visually confirmed to render emoji correctly.
-export function buildWhatsappAppUrl(phone, message) {
-  return `https://wa.me/${digitsOnly(phone)}?text=${encodeURIComponent(message)}`;
 }
 
 export const TEST_RECIPIENTS = [


### PR DESCRIPTION
## Summary
Follow-up to #54. Confirmed via manual test on stage: WhatsApp Desktop corrupts emoji when opened via `wa.me` — every emoji in a test message came through as U+FFFD replacement characters. Researched whether there's a known fix/plugin; there isn't one (Meta's app is closed-source, no plugin ecosystem, and the corruption pattern points to a bug in the app's own text= parameter decoding, not our encoding).

Removes the "Probar por la app" button and the now-unused `buildWhatsappAppUrl` helper. Keeps "Probar" (Web), which is confirmed working and is the only real send path.

## Test plan
- [x] Tested locally: templates load, test button (Web) works, no broken references to the removed app button/helper.
- [x] `npm run lint` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)