### PR TITLE
feat: reminder effectiveness card + feedback panel dismiss button

### DIFF
--- a/src/components/widgets/reminder-effectiveness-card.jsx
+++ b/src/components/widgets/reminder-effectiveness-card.jsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import { api } from '../../lib/api';
+import StatCard from './stat-card';
+
+const CATEGORY_META = {
+  retouch: {
+    label: 'Retoque',
+    icon: 'TrendingUp',
+    successWord: 'volvieron a agendar',
+    info: 'De las clientas a las que se les mandó el recordatorio de retoque, qué porcentaje volvió a comprar después.',
+  },
+  reminder: {
+    label: 'Recordatorio de cita',
+    icon: 'Calendar',
+    successWord: 'asistieron',
+    info: 'De las clientas a las que se les recordó su cita de mañana, qué porcentaje sí asistió ese día.',
+  },
+  feedback: {
+    label: 'Encuesta clienta nueva',
+    icon: 'Star',
+    successWord: 'regresaron',
+    info: 'De las clientas nuevas a las que se les mandó la encuesta, qué porcentaje volvió a visitarnos después.',
+  },
+};
+
+const ReminderEffectivenessCard = () => {
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    api.reminderEffectiveness().then((data) => setCategories(data?.categories ?? []));
+  }, []);
+
+  return (
+    <div className="z-status-row">
+      {Object.entries(CATEGORY_META).map(([key, meta]) => {
+        const row = categories.find((c) => c.category === key);
+        return (
+          <StatCard
+            key={key}
+            label={meta.label}
+            value={row?.sent ? `${Math.round((row.rate ?? 0) * 100)}%` : '—'}
+            caption={row?.sent ? `${row.successful} de ${row.sent} ${meta.successWord}` : 'Sin envíos todavía'}
+            icon={meta.icon}
+            info={meta.info}
+            numeralStyle="sans"
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default ReminderEffectivenessCard;

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -82,4 +82,5 @@ export const api = {
   retouchReminders: () => get('/whatsapp/retouch-reminders'),
   newClientFeedback: () => get('/whatsapp/new-client-feedback'),
   dismissReminder: (body) => post('/whatsapp/dismissals', body),
+  reminderEffectiveness: () => get('/whatsapp/reminder-effectiveness'),
 };

--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -7,6 +7,7 @@ import DataTable from '../components/widgets/data-table';
 import ApptStatus from '../components/widgets/appt-status';
 import AppointmentReminders from '../components/widgets/appointment-reminders';
 import ReminderCampaignPanel from '../components/widgets/reminder-campaign-panel';
+import ReminderEffectivenessCard from '../components/widgets/reminder-effectiveness-card';
 import Badge from '../components/ui/badge';
 import { ChevronLeft, ChevronRight, CheckCircle, Clock, XCircle } from 'lucide-react';
 
@@ -393,7 +394,7 @@ Será un placer atenderte 💕 Bonito día! ☺️`}
         templateInfo="Se manda a clientas cuya visita de hoy fue la primera vez que nos visitan. Usa {nombre} para su primer nombre."
         listEyebrow="Clientas nuevas"
         listTitle="Clientas nuevas de hoy"
-        listInfo="Cada clic sincroniza con AgendaPro primero y luego trae a las clientas cuya primera visita registrada con nosotras fue hoy."
+        listInfo="Cada clic sincroniza con AgendaPro primero y trae a las clientas cuya primera visita fue en los últimos 3 días. Se queda en la lista hasta que le mandes el mensaje o la quites manualmente con la ✕ — no desaparece sola."
         syncButtonLabel="Sincronizar clientas nuevas de hoy"
         defaultTemplateName="Encuesta clienta nueva"
         defaultTemplateBody={`¡Hola! 🌸
@@ -408,7 +409,10 @@ Tu experiencia es muy valiosa para nosotras y nos ayuda a seguir creando momento
         storageKey="zenya.newClientFeedback.lastSync"
         emptyBeforeSyncText='Da clic en "Sincronizar clientas nuevas de hoy" para ver quién visitó por primera vez.'
         emptyAfterSyncText="No hay clientas nuevas hoy."
+        dismissable
       />
+
+      <ReminderEffectivenessCard />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- New `ReminderEffectivenessCard`: three stat tiles (retoque, recordatorio de cita, encuesta clienta nueva) showing sent/successful/rate from the new `/whatsapp/reminder-effectiveness` endpoint, at the bottom of Citas.
- Wires `dismissable` on the new-client-feedback panel now that it carries candidates over instead of clearing daily (backend PR #33, already merged/deployed).

Requires zenya-api #33 (already merged/deployed).

## Test plan
- [x] `npm run lint` and `npm run build` clean.
- [x] Verified locally end-to-end: feedback panel shows a ✕ dismiss button, effectiveness card renders real data from existing sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)