### PR TITLE
feat: Horas tab (staff hours/vacation ledger) + notification bell

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import SectionTitle from './components/widgets/section-title';
 import DateRangePicker from './components/ui/date-range-picker';
 import { SkeletonCard } from './components/ui/skeleton';
 import IconButton from './components/ui/icon-button';
+import NotificationBell from './components/widgets/notification-bell';
 
 import Login from './pages/login';
 import Overview from './pages/overview';
@@ -208,6 +209,7 @@ const App = () => {
               {!HIDE_RANGE.has(active) && (
                 <DateRangePicker value={dateRange} onChange={setDateRange} className="z-hide-sm" />
               )}
+              <NotificationBell onNavigate={navigate} />
               <IconButton
                 label={theme === 'dark' ? 'Modo claro' : 'Modo oscuro'}
                 variant="outline"

--- a/src/components/widgets/notification-bell.jsx
+++ b/src/components/widgets/notification-bell.jsx
@@ -63,7 +63,10 @@ const NotificationBell = ({ onNavigate }) => {
   const ref = useRef(null);
 
   const load = useCallback(() => {
-    api.alerts().then(setAlerts).catch(() => {});
+    api
+      .alerts()
+      .then(setAlerts)
+      .catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/src/components/widgets/notification-bell.jsx
+++ b/src/components/widgets/notification-bell.jsx
@@ -1,0 +1,246 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Bell, Calendar, Palmtree, Clock3 } from 'lucide-react';
+import { api } from '../../lib/api';
+
+const POLL_MS = 60000;
+
+const SectionLabel = ({ children }) => (
+  <div
+    style={{
+      fontFamily: 'var(--font-label)',
+      fontSize: 'var(--text-2xs)',
+      fontWeight: 'var(--fw-semibold)',
+      letterSpacing: 'var(--ls-label)',
+      color: 'var(--text-muted)',
+      textTransform: 'uppercase',
+      padding: '10px 14px 4px',
+    }}
+  >
+    {children}
+  </div>
+);
+
+const AlertRow = ({ icon: Icon, iconColor, title, subtitle, onClick }) => (
+  <button
+    onClick={onClick}
+    style={{
+      display: 'flex',
+      alignItems: 'flex-start',
+      gap: 10,
+      width: '100%',
+      padding: '8px 14px',
+      background: 'transparent',
+      border: 'none',
+      cursor: onClick ? 'pointer' : 'default',
+      textAlign: 'left',
+    }}
+    className="z-row"
+  >
+    <Icon size={15} strokeWidth={1.8} style={{ color: iconColor, marginTop: 2, flexShrink: 0 }} />
+    <div style={{ minWidth: 0 }}>
+      <div
+        style={{
+          fontFamily: 'var(--font-sans)',
+          fontSize: 'var(--text-sm)',
+          fontWeight: 'var(--fw-medium)',
+          color: 'var(--text-heading)',
+        }}
+      >
+        {title}
+      </div>
+      {subtitle && (
+        <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+          {subtitle}
+        </div>
+      )}
+    </div>
+  </button>
+);
+
+const NotificationBell = ({ onNavigate }) => {
+  const [alerts, setAlerts] = useState(null);
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  const load = useCallback(() => {
+    api.alerts().then(setAlerts).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    load();
+    const id = setInterval(load, POLL_MS);
+    return () => clearInterval(id);
+  }, [load]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const goTo = (page) => {
+    setOpen(false);
+    onNavigate?.(page);
+  };
+
+  const totalCount = alerts?.total_count ?? 0;
+  const hasAlerts =
+    (alerts?.pending_reminders?.length ?? 0) +
+      (alerts?.upcoming_vacations?.length ?? 0) +
+      (alerts?.owed_hours?.length ?? 0) >
+    0;
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        title="Notificaciones"
+        style={{
+          position: 'relative',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 38,
+          height: 38,
+          borderRadius: 'var(--radius-sm)',
+          border: '1px solid var(--border-default)',
+          background: open ? 'var(--surface-page)' : 'var(--surface-card)',
+          color: 'var(--text-secondary)',
+          cursor: 'pointer',
+        }}
+      >
+        <Bell size={16} strokeWidth={1.7} />
+        {totalCount > 0 && (
+          <span
+            style={{
+              position: 'absolute',
+              top: -4,
+              right: -4,
+              minWidth: 17,
+              height: 17,
+              padding: '0 4px',
+              borderRadius: 'var(--radius-pill)',
+              background: 'var(--red-600, #dc2626)',
+              color: 'var(--white)',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 10,
+              fontWeight: 700,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              lineHeight: 1,
+            }}
+          >
+            {totalCount > 99 ? '99+' : totalCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            right: 0,
+            zIndex: 200,
+            background: 'var(--surface-card)',
+            border: '1px solid var(--border-default)',
+            borderRadius: 'var(--radius-md)',
+            boxShadow: 'var(--shadow-lg)',
+            minWidth: 300,
+            maxWidth: 340,
+            maxHeight: 420,
+            overflowY: 'auto',
+            paddingBottom: 6,
+          }}
+        >
+          <div
+            style={{
+              padding: '12px 14px',
+              borderBottom: '1px solid var(--border-subtle)',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 'var(--fw-semibold)',
+              color: 'var(--text-heading)',
+            }}
+          >
+            Notificaciones
+          </div>
+
+          {!hasAlerts && (
+            <div
+              style={{
+                padding: '24px 14px',
+                textAlign: 'center',
+                color: 'var(--text-muted)',
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+              }}
+            >
+              Sin notificaciones pendientes.
+            </div>
+          )}
+
+          {alerts?.pending_reminders?.length > 0 && (
+            <>
+              <SectionLabel>Recordatorios pendientes</SectionLabel>
+              {alerts.pending_reminders.map((r) => (
+                <AlertRow
+                  key={r.category}
+                  icon={Calendar}
+                  iconColor="var(--brand-primary)"
+                  title={r.label}
+                  subtitle={`${r.count} por enviar`}
+                  onClick={() => goTo('appointments')}
+                />
+              ))}
+            </>
+          )}
+
+          {alerts?.upcoming_vacations?.length > 0 && (
+            <>
+              <SectionLabel>Vacaciones próximas</SectionLabel>
+              {alerts.upcoming_vacations.map((v) => (
+                <AlertRow
+                  key={`${v.professional_id}-${v.vacation_date}`}
+                  icon={Palmtree}
+                  iconColor="var(--lavender-600, #7c3aed)"
+                  title={[v.first_name, v.last_name].filter(Boolean).join(' ').trim()}
+                  subtitle={
+                    v.days_until === 0
+                      ? 'Es hoy'
+                      : v.days_until === 1
+                        ? 'Es mañana'
+                        : `En ${v.days_until} días · ${v.vacation_date}`
+                  }
+                  onClick={() => goTo('staff')}
+                />
+              ))}
+            </>
+          )}
+
+          {alerts?.owed_hours?.length > 0 && (
+            <>
+              <SectionLabel>Horas pendientes 2+ semanas</SectionLabel>
+              {alerts.owed_hours.map((o) => (
+                <AlertRow
+                  key={o.professional_id}
+                  icon={Clock3}
+                  iconColor="var(--caution)"
+                  title={[o.first_name, o.last_name].filter(Boolean).join(' ').trim()}
+                  subtitle={`Debe desde hace ${o.days_owed} días`}
+                  onClick={() => goTo('staff')}
+                />
+              ))}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationBell;

--- a/src/components/widgets/staff-hours-panel.jsx
+++ b/src/components/widgets/staff-hours-panel.jsx
@@ -1,0 +1,562 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Plus, X } from 'lucide-react';
+import { api } from '../../lib/api';
+import Card from '../ui/card';
+import Badge from '../ui/badge';
+import Button from '../ui/button';
+import IconButton from '../ui/icon-button';
+import Select from '../ui/select';
+import DataTable from './data-table';
+
+const MONTHS_SHORT = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+
+// The only individually-tracked manicuristas — "Cosmetología" and "Lashes y
+// cejas" are shared AgendaPro accounts for a service, not people who can owe
+// or be owed time, so they're excluded from this ledger.
+const TRACKED_PROFESSIONAL_NAMES = ['Danna Aquino', 'Guadalupe Villegas Martínez', 'Liliana Martínez'];
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  const [y, m, d] = iso.split('-').map(Number);
+  return `${d} ${MONTHS_SHORT[m - 1]} ${y}`;
+}
+
+function fmtDuration(minutes) {
+  const abs = Math.abs(minutes);
+  const h = Math.floor(abs / 60);
+  const m = abs % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+}
+
+// 1 día = jornada de 8 horas, para convertir la entrada del formulario a minutos.
+function minutesFromInput(amount, unit) {
+  const n = Number(amount) || 0;
+  if (unit === 'horas') return Math.round(n * 60);
+  if (unit === 'dias') return Math.round(n * 480);
+  return Math.round(n);
+}
+
+const inputStyle = {
+  padding: '8px 10px',
+  borderRadius: 6,
+  border: '1px solid var(--border-subtle)',
+  fontFamily: 'var(--font-sans)',
+  fontSize: 'var(--text-sm)',
+  color: 'var(--text-body)',
+  background: 'var(--surface-card)',
+};
+
+const labelStyle = {
+  fontFamily: 'var(--font-sans)',
+  fontSize: 'var(--text-xs)',
+  fontWeight: 'var(--fw-medium)',
+  color: 'var(--text-secondary)',
+};
+
+const EmptyRow = ({ text }) => (
+  <div
+    style={{
+      padding: '16px 0',
+      textAlign: 'center',
+      color: 'var(--text-muted)',
+      fontFamily: 'var(--font-sans)',
+      fontSize: 'var(--text-sm)',
+    }}
+  >
+    {text}
+  </div>
+);
+
+const Stat = ({ label, value, highlight }) => (
+  <div>
+    <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+      {label}
+    </div>
+    <div
+      style={{
+        fontFamily: 'var(--font-display)',
+        fontSize: 'var(--text-xl)',
+        fontWeight: 700,
+        color: highlight ? 'var(--brand-primary)' : 'var(--text-display)',
+      }}
+    >
+      {value}
+    </div>
+  </div>
+);
+
+const BalanceCard = ({ summary, active, onSelect }) => {
+  const name = [summary.first_name, summary.last_name].filter(Boolean).join(' ').trim();
+  const owed = summary.net_minutes > 0;
+  const owes = summary.net_minutes < 0;
+
+  let tone = 'positive';
+  let statusText = 'Sin pendientes';
+  if (owed) {
+    tone = 'lavender';
+    statusText = `Le debemos ${fmtDuration(summary.net_minutes)}`;
+  } else if (owes) {
+    const daysOwed = summary.since_date
+      ? Math.floor((Date.now() - new Date(summary.since_date + 'T00:00:00').getTime()) / 86400000)
+      : 0;
+    tone = daysOwed >= 14 ? 'negative' : 'caution';
+    statusText = `Debe ${fmtDuration(summary.net_minutes)}`;
+  }
+
+  return (
+    <button
+      onClick={onSelect}
+      style={{
+        textAlign: 'left',
+        cursor: 'pointer',
+        padding: 16,
+        borderRadius: 'var(--radius-lg)',
+        border: active ? '2px solid var(--brand-primary)' : '1px solid var(--border-subtle)',
+        background: 'var(--surface-card)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div style={{ fontFamily: 'var(--font-sans)', fontWeight: 'var(--fw-semibold)', color: 'var(--text-heading)' }}>
+        {name}
+      </div>
+      <Badge tone={tone} dot>
+        {statusText}
+      </Badge>
+      {summary.since_date && (owed || owes) && (
+        <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+          desde {fmtDate(summary.since_date)}
+        </div>
+      )}
+      <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+        Vacaciones: {summary.vacation_remaining_days} de {summary.vacation_total_days} días disponibles
+      </div>
+    </button>
+  );
+};
+
+const TimeEntrySection = ({ professional, entries, onChange }) => {
+  const [showForm, setShowForm] = useState(false);
+  const [entryDate, setEntryDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [entryType, setEntryType] = useState('extra');
+  const [amount, setAmount] = useState('');
+  const [unit, setUnit] = useState('minutos');
+  const [reason, setReason] = useState('');
+  const [clientName, setClientName] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const resetForm = () => {
+    setEntryDate(new Date().toISOString().slice(0, 10));
+    setEntryType('extra');
+    setAmount('');
+    setUnit('minutos');
+    setReason('');
+    setClientName('');
+  };
+
+  const handleSubmit = async () => {
+    const minutes = minutesFromInput(amount, unit);
+    if (!minutes) return;
+    setSaving(true);
+    try {
+      await api.createStaffTimeEntry({
+        professional_id: professional.id,
+        entry_date: entryDate,
+        entry_type: entryType,
+        minutes,
+        reason: reason || null,
+        client_name: entryType === 'extra' && clientName ? clientName : null,
+      });
+      resetForm();
+      setShowForm(false);
+      onChange();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleVoid = async (id) => {
+    await api.updateStaffTimeEntry(id, { active: false });
+    onChange();
+  };
+
+  const columns = [
+    { key: 'entry_date', label: 'Fecha' },
+    { key: 'entry_type', label: 'Tipo' },
+    { key: 'minutes', label: 'Tiempo', align: 'right' },
+    { key: 'reason', label: 'Motivo' },
+    { key: 'client_name', label: 'Clienta' },
+    { key: 'actions', label: '', align: 'right' },
+  ];
+
+  return (
+    <Card
+      eyebrow="Registro"
+      title={`Horas — ${professional.first_name?.trim()}`}
+      info="Extra: tiempo que trabajó de más y se le debe. Debe: tiempo que ella debe al salón (faltas, permisos, salidas anticipadas)."
+      action={
+        <Button size="sm" variant="soft" iconLeft={Plus} onClick={() => setShowForm((v) => !v)}>
+          Agregar
+        </Button>
+      }
+    >
+      {showForm && (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 10,
+            alignItems: 'flex-end',
+            padding: '4px 0 16px',
+            borderBottom: '1px solid var(--border-subtle)',
+            marginBottom: 16,
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <label style={labelStyle}>Fecha</label>
+            <input type="date" value={entryDate} onChange={(e) => setEntryDate(e.target.value)} style={inputStyle} />
+          </div>
+          <Select
+            label="Tipo"
+            value={entryType}
+            onChange={setEntryType}
+            size="sm"
+            options={[
+              { value: 'extra', label: 'Extra (se le debe)' },
+              { value: 'debe', label: 'Debe (ella debe)' },
+            ]}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <label style={labelStyle}>Cantidad</label>
+            <input
+              type="number"
+              min="0"
+              step="1"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              style={{ ...inputStyle, width: 90 }}
+            />
+          </div>
+          <Select
+            value={unit}
+            onChange={setUnit}
+            size="sm"
+            options={[
+              { value: 'minutos', label: 'Minutos' },
+              { value: 'horas', label: 'Horas' },
+              { value: 'dias', label: 'Días (8h)' },
+            ]}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 140 }}>
+            <label style={labelStyle}>Motivo</label>
+            <input
+              type="text"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              style={inputStyle}
+              placeholder="Opcional"
+            />
+          </div>
+          {entryType === 'extra' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 140 }}>
+              <label style={labelStyle}>Clienta</label>
+              <input
+                type="text"
+                value={clientName}
+                onChange={(e) => setClientName(e.target.value)}
+                style={inputStyle}
+                placeholder="Opcional"
+              />
+            </div>
+          )}
+          <Button size="sm" onClick={handleSubmit} disabled={saving || !amount}>
+            Guardar
+          </Button>
+        </div>
+      )}
+
+      {entries.length ? (
+        <DataTable
+          columns={columns}
+          rows={entries}
+          renderCell={(row, key) => {
+            if (key === 'entry_date') return fmtDate(row.entry_date);
+            if (key === 'entry_type')
+              return (
+                <Badge tone={row.entry_type === 'extra' ? 'lavender' : 'caution'}>
+                  {row.entry_type === 'extra' ? 'Extra' : 'Debe'}
+                </Badge>
+              );
+            if (key === 'minutes') return fmtDuration(row.minutes);
+            if (key === 'reason') return row.reason ?? '—';
+            if (key === 'client_name') return row.client_name ?? '—';
+            if (key === 'actions')
+              return <IconButton icon={X} title="Anular" size="sm" variant="ghost" onClick={() => handleVoid(row.id)} />;
+            return row[key];
+          }}
+        />
+      ) : (
+        <EmptyRow text="Sin registros todavía." />
+      )}
+    </Card>
+  );
+};
+
+const VacationSection = ({ professional, vacations, allotment, summary, onChange }) => {
+  const [showForm, setShowForm] = useState(false);
+  const [vacationDate, setVacationDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [isHalfDay, setIsHalfDay] = useState(false);
+  const [status, setStatus] = useState('taken');
+  const [note, setNote] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const [totalDaysDraft, setTotalDaysDraft] = useState(String(allotment?.total_days ?? summary?.vacation_total_days ?? 0));
+  const [savingAllotment, setSavingAllotment] = useState(false);
+
+  useEffect(() => {
+    setTotalDaysDraft(String(allotment?.total_days ?? summary?.vacation_total_days ?? 0));
+    // eslint-disable-next-line
+  }, [professional.id, allotment]);
+
+  const handleSaveAllotment = async () => {
+    setSavingAllotment(true);
+    try {
+      await api.upsertStaffAllotment(professional.id, { total_days: Number(totalDaysDraft) || 0 });
+      onChange();
+    } finally {
+      setSavingAllotment(false);
+    }
+  };
+
+  const resetForm = () => {
+    setVacationDate(new Date().toISOString().slice(0, 10));
+    setIsHalfDay(false);
+    setStatus('taken');
+    setNote('');
+  };
+
+  const handleSubmit = async () => {
+    setSaving(true);
+    try {
+      await api.createStaffVacation({
+        professional_id: professional.id,
+        vacation_date: vacationDate,
+        is_half_day: isHalfDay,
+        status,
+        note: note || null,
+      });
+      resetForm();
+      setShowForm(false);
+      onChange();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleVoid = async (id) => {
+    await api.updateStaffVacation(id, { active: false });
+    onChange();
+  };
+
+  const columns = [
+    { key: 'vacation_date', label: 'Fecha' },
+    { key: 'is_half_day', label: 'Días' },
+    { key: 'status', label: 'Estado' },
+    { key: 'note', label: 'Nota' },
+    { key: 'actions', label: '', align: 'right' },
+  ];
+
+  return (
+    <Card
+      eyebrow="Vacaciones"
+      title={`Vacaciones — ${professional.first_name?.trim()}`}
+      action={
+        <Button size="sm" variant="soft" iconLeft={Plus} onClick={() => setShowForm((v) => !v)}>
+          Agregar
+        </Button>
+      }
+    >
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24, marginBottom: 16, alignItems: 'flex-end' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <label style={labelStyle}>Días al año</label>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <input
+              type="number"
+              min="0"
+              step="0.5"
+              value={totalDaysDraft}
+              onChange={(e) => setTotalDaysDraft(e.target.value)}
+              style={{ ...inputStyle, width: 70 }}
+            />
+            <Button size="sm" variant="secondary" onClick={handleSaveAllotment} disabled={savingAllotment}>
+              Guardar
+            </Button>
+          </div>
+        </div>
+        {summary && (
+          <>
+            <Stat label="Tomados" value={summary.vacation_taken_days} />
+            <Stat label="Solicitados" value={summary.vacation_requested_days} />
+            <Stat label="Disponibles" value={summary.vacation_remaining_days} highlight />
+          </>
+        )}
+      </div>
+
+      {showForm && (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 10,
+            alignItems: 'flex-end',
+            padding: '4px 0 16px',
+            borderBottom: '1px solid var(--border-subtle)',
+            marginBottom: 16,
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <label style={labelStyle}>Fecha</label>
+            <input
+              type="date"
+              value={vacationDate}
+              onChange={(e) => setVacationDate(e.target.value)}
+              style={inputStyle}
+            />
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, ...labelStyle }}>
+            <input type="checkbox" checked={isHalfDay} onChange={(e) => setIsHalfDay(e.target.checked)} />
+            Medio día
+          </label>
+          <Select
+            label="Estado"
+            value={status}
+            onChange={setStatus}
+            size="sm"
+            options={[
+              { value: 'taken', label: 'Tomado' },
+              { value: 'requested', label: 'Solicitado' },
+            ]}
+          />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 160 }}>
+            <label style={labelStyle}>Nota</label>
+            <input type="text" value={note} onChange={(e) => setNote(e.target.value)} style={inputStyle} placeholder="Opcional" />
+          </div>
+          <Button size="sm" onClick={handleSubmit} disabled={saving}>
+            Guardar
+          </Button>
+        </div>
+      )}
+
+      {vacations.length ? (
+        <DataTable
+          columns={columns}
+          rows={vacations}
+          renderCell={(row, key) => {
+            if (key === 'vacation_date') return fmtDate(row.vacation_date);
+            if (key === 'is_half_day') return row.is_half_day ? '½ día' : '1 día';
+            if (key === 'status')
+              return (
+                <Badge tone={row.status === 'taken' ? 'positive' : 'caution'}>
+                  {row.status === 'taken' ? 'Tomado' : 'Solicitado'}
+                </Badge>
+              );
+            if (key === 'note') return row.note ?? '—';
+            if (key === 'actions')
+              return <IconButton icon={X} title="Anular" size="sm" variant="ghost" onClick={() => handleVoid(row.id)} />;
+            return row[key];
+          }}
+        />
+      ) : (
+        <EmptyRow text="Sin vacaciones registradas." />
+      )}
+    </Card>
+  );
+};
+
+const StaffHoursPanel = () => {
+  const [professionals, setProfessionals] = useState([]);
+  const [balances, setBalances] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const [entries, setEntries] = useState([]);
+  const [vacations, setVacations] = useState([]);
+  const [allotment, setAllotment] = useState(null);
+
+  const loadBalances = useCallback(async () => {
+    const [profList, balanceData] = await Promise.all([api.professionals(), api.staffHoursBalance()]);
+    const tracked = (profList ?? []).filter((p) => TRACKED_PROFESSIONAL_NAMES.includes((p.first_name || '').trim()));
+    setProfessionals(tracked);
+    const trackedIds = new Set(tracked.map((p) => p.id));
+    setBalances((balanceData?.professionals ?? []).filter((s) => trackedIds.has(s.professional_id)));
+    setSelectedId((prev) => prev ?? tracked[0]?.id ?? null);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadBalances();
+    // eslint-disable-next-line
+  }, []);
+
+  const loadDetail = useCallback(async (professionalId) => {
+    if (!professionalId) return;
+    const [entryList, vacationList, allotmentList] = await Promise.all([
+      api.staffTimeEntries({ professional_id: professionalId }),
+      api.staffVacations({ professional_id: professionalId }),
+      api.staffAllotments(),
+    ]);
+    setEntries(entryList ?? []);
+    setVacations(vacationList ?? []);
+    setAllotment((allotmentList ?? []).find((a) => a.professional_id === professionalId) ?? null);
+  }, []);
+
+  useEffect(() => {
+    loadDetail(selectedId);
+  }, [selectedId, loadDetail]);
+
+  const refreshAll = async () => {
+    await Promise.all([loadBalances(), loadDetail(selectedId)]);
+  };
+
+  const selectedProfessional = professionals.find((p) => p.id === selectedId);
+  const selectedSummary = balances.find((s) => s.professional_id === selectedId);
+
+  if (loading) return <EmptyRow text="Cargando..." />;
+
+  if (!professionals.length) {
+    return <EmptyRow text="No se encontraron las manicuristas en AgendaPro." />;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 12 }}>
+        {balances.map((s) => (
+          <BalanceCard
+            key={s.professional_id}
+            summary={s}
+            active={s.professional_id === selectedId}
+            onSelect={() => setSelectedId(s.professional_id)}
+          />
+        ))}
+      </div>
+
+      {selectedProfessional && (
+        <>
+          <TimeEntrySection professional={selectedProfessional} entries={entries} onChange={refreshAll} />
+          <VacationSection
+            professional={selectedProfessional}
+            vacations={vacations}
+            allotment={allotment}
+            summary={selectedSummary}
+            onChange={refreshAll}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default StaffHoursPanel;

--- a/src/components/widgets/staff-hours-panel.jsx
+++ b/src/components/widgets/staff-hours-panel.jsx
@@ -215,10 +215,10 @@ const TimeEntrySection = ({ professional, entries, onChange }) => {
             marginBottom: 16,
           }}
         >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-            <label style={labelStyle}>Fecha</label>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={labelStyle}>Fecha</span>
             <input type="date" value={entryDate} onChange={(e) => setEntryDate(e.target.value)} style={inputStyle} />
-          </div>
+          </label>
           <Select
             label="Tipo"
             value={entryType}
@@ -229,8 +229,8 @@ const TimeEntrySection = ({ professional, entries, onChange }) => {
               { value: 'debe', label: 'Debe (ella debe)' },
             ]}
           />
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-            <label style={labelStyle}>Cantidad</label>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={labelStyle}>Cantidad</span>
             <input
               type="number"
               min="0"
@@ -239,7 +239,7 @@ const TimeEntrySection = ({ professional, entries, onChange }) => {
               onChange={(e) => setAmount(e.target.value)}
               style={{ ...inputStyle, width: 90 }}
             />
-          </div>
+          </label>
           <Select
             value={unit}
             onChange={setUnit}
@@ -250,8 +250,8 @@ const TimeEntrySection = ({ professional, entries, onChange }) => {
               { value: 'dias', label: 'Días (8h)' },
             ]}
           />
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 140 }}>
-            <label style={labelStyle}>Motivo</label>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 140 }}>
+            <span style={labelStyle}>Motivo</span>
             <input
               type="text"
               value={reason}
@@ -259,10 +259,10 @@ const TimeEntrySection = ({ professional, entries, onChange }) => {
               style={inputStyle}
               placeholder="Opcional"
             />
-          </div>
+          </label>
           {entryType === 'extra' && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 140 }}>
-              <label style={labelStyle}>Clienta</label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 140 }}>
+              <span style={labelStyle}>Clienta</span>
               <input
                 type="text"
                 value={clientName}
@@ -270,7 +270,7 @@ const TimeEntrySection = ({ professional, entries, onChange }) => {
                 style={inputStyle}
                 placeholder="Opcional"
               />
-            </div>
+            </label>
           )}
           <Button size="sm" onClick={handleSubmit} disabled={saving || !amount}>
             Guardar
@@ -294,7 +294,9 @@ const TimeEntrySection = ({ professional, entries, onChange }) => {
             if (key === 'reason') return row.reason ?? '—';
             if (key === 'client_name') return row.client_name ?? '—';
             if (key === 'actions')
-              return <IconButton icon={X} title="Anular" size="sm" variant="ghost" onClick={() => handleVoid(row.id)} />;
+              return (
+                <IconButton icon={X} title="Anular" size="sm" variant="ghost" onClick={() => handleVoid(row.id)} />
+              );
             return row[key];
           }}
         />
@@ -313,7 +315,9 @@ const VacationSection = ({ professional, vacations, allotment, summary, onChange
   const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
 
-  const [totalDaysDraft, setTotalDaysDraft] = useState(String(allotment?.total_days ?? summary?.vacation_total_days ?? 0));
+  const [totalDaysDraft, setTotalDaysDraft] = useState(
+    String(allotment?.total_days ?? summary?.vacation_total_days ?? 0)
+  );
   const [savingAllotment, setSavingAllotment] = useState(false);
 
   useEffect(() => {
@@ -381,9 +385,12 @@ const VacationSection = ({ professional, vacations, allotment, summary, onChange
     >
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24, marginBottom: 16, alignItems: 'flex-end' }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <label style={labelStyle}>Días al año</label>
+          <label htmlFor={`allotment-${professional.id}`} style={labelStyle}>
+            Días al año
+          </label>
           <div style={{ display: 'flex', gap: 6 }}>
             <input
+              id={`allotment-${professional.id}`}
               type="number"
               min="0"
               step="0.5"
@@ -417,15 +424,15 @@ const VacationSection = ({ professional, vacations, allotment, summary, onChange
             marginBottom: 16,
           }}
         >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-            <label style={labelStyle}>Fecha</label>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={labelStyle}>Fecha</span>
             <input
               type="date"
               value={vacationDate}
               onChange={(e) => setVacationDate(e.target.value)}
               style={inputStyle}
             />
-          </div>
+          </label>
           <label style={{ display: 'flex', alignItems: 'center', gap: 6, ...labelStyle }}>
             <input type="checkbox" checked={isHalfDay} onChange={(e) => setIsHalfDay(e.target.checked)} />
             Medio día
@@ -440,10 +447,16 @@ const VacationSection = ({ professional, vacations, allotment, summary, onChange
               { value: 'requested', label: 'Solicitado' },
             ]}
           />
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 160 }}>
-            <label style={labelStyle}>Nota</label>
-            <input type="text" value={note} onChange={(e) => setNote(e.target.value)} style={inputStyle} placeholder="Opcional" />
-          </div>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 160 }}>
+            <span style={labelStyle}>Nota</span>
+            <input
+              type="text"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              style={inputStyle}
+              placeholder="Opcional"
+            />
+          </label>
           <Button size="sm" onClick={handleSubmit} disabled={saving}>
             Guardar
           </Button>
@@ -465,7 +478,9 @@ const VacationSection = ({ professional, vacations, allotment, summary, onChange
               );
             if (key === 'note') return row.note ?? '—';
             if (key === 'actions')
-              return <IconButton icon={X} title="Anular" size="sm" variant="ghost" onClick={() => handleVoid(row.id)} />;
+              return (
+                <IconButton icon={X} title="Anular" size="sm" variant="ghost" onClick={() => handleVoid(row.id)} />
+              );
             return row[key];
           }}
         />

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -83,4 +83,18 @@ export const api = {
   newClientFeedback: () => get('/whatsapp/new-client-feedback'),
   dismissReminder: (body) => post('/whatsapp/dismissals', body),
   reminderEffectiveness: () => get('/whatsapp/reminder-effectiveness'),
+
+  // staff hours — "Adeudo de tiempo extra manicuristas" ledger + vacations
+  staffHoursBalance: () => get('/staff-hours/balance'),
+  staffTimeEntries: (params) => get('/staff-hours/time-entries', params),
+  createStaffTimeEntry: (body) => post('/staff-hours/time-entries', body),
+  updateStaffTimeEntry: (id, body) => put(`/staff-hours/time-entries/${id}`, body),
+  staffVacations: (params) => get('/staff-hours/vacations', params),
+  createStaffVacation: (body) => post('/staff-hours/vacations', body),
+  updateStaffVacation: (id, body) => put(`/staff-hours/vacations/${id}`, body),
+  staffAllotments: () => get('/staff-hours/allotments'),
+  upsertStaffAllotment: (professionalId, body) => put(`/staff-hours/allotments/${professionalId}`, body),
+
+  // alerts
+  alerts: () => get('/alerts'),
 };

--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -79,226 +79,226 @@ const Staff = ({ dateRange }) => {
 
       {tab === 'performance' && (
         <>
-      <div className="z-kpi-grid">
-        <StatCard
-          label="Top empleada"
-          value={topStaff?.name.split(' ')[0] ?? '—'}
-          caption={topStaff ? `${money(topStaff.rev)} este mes` : '—'}
-          icon="Award"
-          numeralStyle="sans"
-        />
-        <StatCard
-          label="Ingresos equipo"
-          value={totalRev ? money(totalRev) : '—'}
-          caption="en el periodo"
-          icon="TrendingUp"
-          spark={[]}
-          sparkColor="var(--chart-1)"
-        />
-        <StatCard
-          label="Total citas"
-          value={totalAppts ? totalAppts.toLocaleString('es-MX') : '—'}
-          caption="en el periodo"
-          icon="Calendar"
-        />
-        <StatCard
-          label="Empleadas activas"
-          value={staff.length ? String(staff.length) : '—'}
-          caption="con ventas en el periodo"
-          icon="Users"
-        />
-      </div>
-
-      <div className="z-staff-grid">
-        {staff.map((s, i) => (
-          <StaffCard key={s.name} s={s} rank={i + 1} maxRev={maxRev} money={money} />
-        ))}
-      </div>
-
-      <div className="z-2col">
-        <Card eyebrow="Ranking" title="Ingresos por persona">
-          {staff.map((s, i) => (
-            <RankRow
-              key={s.name}
-              rank={i + 1}
-              label={s.name}
-              sublabel={s.appts + ' citas'}
-              value={money(s.rev)}
-              ratio={s.rev / maxRev}
-              color={s.color}
-              last={i === staff.length - 1 && !(unassigned?.count > 0)}
+          <div className="z-kpi-grid">
+            <StatCard
+              label="Top empleada"
+              value={topStaff?.name.split(' ')[0] ?? '—'}
+              caption={topStaff ? `${money(topStaff.rev)} este mes` : '—'}
+              icon="Award"
+              numeralStyle="sans"
             />
-          ))}
-          {unassigned?.count > 0 && (
-            <RankRow
-              rank={staff.length + 1}
-              label="No asignados"
-              sublabel={unassigned.count + ' servicios'}
-              value={money(unassigned.revenue)}
-              ratio={unassigned.revenue / maxRev}
-              color="var(--chart-compare)"
-              last
+            <StatCard
+              label="Ingresos equipo"
+              value={totalRev ? money(totalRev) : '—'}
+              caption="en el periodo"
+              icon="TrendingUp"
+              spark={[]}
+              sparkColor="var(--chart-1)"
             />
-          )}
-        </Card>
+            <StatCard
+              label="Total citas"
+              value={totalAppts ? totalAppts.toLocaleString('es-MX') : '—'}
+              caption="en el periodo"
+              icon="Calendar"
+            />
+            <StatCard
+              label="Empleadas activas"
+              value={staff.length ? String(staff.length) : '—'}
+              caption="con ventas en el periodo"
+              icon="Users"
+            />
+          </div>
 
-        <Card eyebrow="Carga" title="Distribución de trabajo">
-          <div style={{ display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap' }}>
-            <Donut
-              data={staff.map((s) => ({ value: s.appts, color: s.color }))}
-              size={150}
-              thickness={20}
-              centerValue={totalAppts}
-              centerLabel="citas"
-            />
-            <div style={{ flex: 1, minWidth: 140 }}>
+          <div className="z-staff-grid">
+            {staff.map((s, i) => (
+              <StaffCard key={s.name} s={s} rank={i + 1} maxRev={maxRev} money={money} />
+            ))}
+          </div>
+
+          <div className="z-2col">
+            <Card eyebrow="Ranking" title="Ingresos por persona">
               {staff.map((s, i) => (
-                <div
+                <RankRow
                   key={s.name}
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    padding: '6px 0',
-                    borderBottom: i < staff.length - 1 ? '1px solid var(--border-subtle)' : 'none',
-                  }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <span style={{ width: 10, height: 10, borderRadius: 3, background: s.color, flexShrink: 0 }} />
-                    <span
+                  rank={i + 1}
+                  label={s.name}
+                  sublabel={s.appts + ' citas'}
+                  value={money(s.rev)}
+                  ratio={s.rev / maxRev}
+                  color={s.color}
+                  last={i === staff.length - 1 && !(unassigned?.count > 0)}
+                />
+              ))}
+              {unassigned?.count > 0 && (
+                <RankRow
+                  rank={staff.length + 1}
+                  label="No asignados"
+                  sublabel={unassigned.count + ' servicios'}
+                  value={money(unassigned.revenue)}
+                  ratio={unassigned.revenue / maxRev}
+                  color="var(--chart-compare)"
+                  last
+                />
+              )}
+            </Card>
+
+            <Card eyebrow="Carga" title="Distribución de trabajo">
+              <div style={{ display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap' }}>
+                <Donut
+                  data={staff.map((s) => ({ value: s.appts, color: s.color }))}
+                  size={150}
+                  thickness={20}
+                  centerValue={totalAppts}
+                  centerLabel="citas"
+                />
+                <div style={{ flex: 1, minWidth: 140 }}>
+                  {staff.map((s, i) => (
+                    <div
+                      key={s.name}
                       style={{
-                        fontFamily: 'var(--font-sans)',
-                        fontSize: 'var(--text-sm)',
-                        color: 'var(--text-body)',
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        padding: '6px 0',
+                        borderBottom: i < staff.length - 1 ? '1px solid var(--border-subtle)' : 'none',
                       }}
                     >
-                      {s.name.split(' ')[0]}
-                    </span>
-                  </div>
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-sans)',
-                      fontSize: 'var(--text-sm)',
-                      fontWeight: 'var(--fw-semibold)',
-                      color: 'var(--text-heading)',
-                    }}
-                  >
-                    {totalAppts ? `${Math.round((s.appts / totalAppts) * 100)}%` : '—'}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        </Card>
-      </div>
-
-      {(sharedBreakdown ?? []).some((g) => g.total_count > 0) && (
-        <div className="z-2col">
-          {(sharedBreakdown ?? [])
-            .filter((g) => g.total_count > 0)
-            .map((group) => {
-              const maxPersonRev = Math.max(...group.people.map((p) => p.revenue), 1);
-              return (
-                <Card
-                  key={group.provider_id}
-                  eyebrow="¿Quién atendió?"
-                  title={group.category}
-                  info="Estas cuentas las comparten varias personas; quién atendió se identifica por el nombre escrito en la nota de la cita (ej. 'Atiende Chio'). Los servicios cuya nota no menciona a nadie conocido quedan como No asignados."
-                >
-                  {group.people.map((p, i) => (
-                    <RankRow
-                      key={p.name}
-                      rank={i + 1}
-                      label={p.name}
-                      sublabel={p.count + ' servicios'}
-                      value={money(p.revenue)}
-                      ratio={p.revenue / maxPersonRev}
-                      color={p.name === 'No asignados' ? 'var(--chart-compare)' : CHART[i % CHART.length]}
-                      last={i === group.people.length - 1}
-                    />
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <span style={{ width: 10, height: 10, borderRadius: 3, background: s.color, flexShrink: 0 }} />
+                        <span
+                          style={{
+                            fontFamily: 'var(--font-sans)',
+                            fontSize: 'var(--text-sm)',
+                            color: 'var(--text-body)',
+                          }}
+                        >
+                          {s.name.split(' ')[0]}
+                        </span>
+                      </div>
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-sans)',
+                          fontSize: 'var(--text-sm)',
+                          fontWeight: 'var(--fw-semibold)',
+                          color: 'var(--text-heading)',
+                        }}
+                      >
+                        {totalAppts ? `${Math.round((s.appts / totalAppts) * 100)}%` : '—'}
+                      </span>
+                    </div>
                   ))}
-                </Card>
-              );
-            })}
-        </div>
-      )}
-
-      <Card eyebrow="Servicios" title="Volumen por persona">
-        <BarChart
-          data={staff.map((s) => ({ label: s.name.split(' ')[0], value: s.appts, color: s.color }))}
-          height={200}
-          yFormat={(v) => String(Math.round(v))}
-        />
-      </Card>
-
-      <Card eyebrow="Detalle" title="Ranking del equipo">
-        <DataTable
-          columns={COLUMNS}
-          rows={staff}
-          renderCell={(row, key, ri) => {
-            if (key === 'rank')
-              return <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>{(ri ?? 0) + 1}</span>;
-            if (key === 'name')
-              return (
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                  <Avatar name={row.name} size="sm" tone={ri === 0 ? 'rose' : ri === 1 ? 'lavender' : 'ink'} />
-                  <span style={{ fontWeight: 'var(--fw-medium)', color: 'var(--text-heading)' }}>{row.name}</span>
                 </div>
-              );
-            if (key === 'appts') return row.appts;
-            if (key === 'recurring')
-              return row.recurringClients != null ? (
-                <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{row.recurringClients}</span>
-              ) : (
-                '—'
-              );
-            if (key === 'avg') return money(row.avg);
-            if (key === 'rev')
-              return <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{money(row.rev)}</span>;
-            return row[key] ?? '—';
-          }}
-        />
-      </Card>
-
-      {unassigned?.count > 0 && (
-        <Card
-          eyebrow="Sin profesional"
-          title="Servicios no asignados"
-          info="Servicios cobrados sin profesional asignado en AgendaPro (diseños, cejas, extras de walk-in). Cuentan en los ingresos totales pero no aparecen en el ranking del equipo porque no hay a quién atribuirlos."
-        >
-          <div
-            style={{
-              display: 'flex',
-              gap: 24,
-              marginBottom: 12,
-              fontFamily: 'var(--font-sans)',
-              fontSize: 'var(--text-sm)',
-              color: 'var(--text-secondary)',
-            }}
-          >
-            <span>
-              Total: <strong style={{ color: 'var(--text-display)' }}>{money(unassigned.revenue)}</strong>
-            </span>
-            <span>
-              Servicios: <strong style={{ color: 'var(--text-display)' }}>{unassigned.count}</strong>
-            </span>
+              </div>
+            </Card>
           </div>
-          <DataTable
-            columns={UNASSIGNED_COLUMNS}
-            rows={unassigned.items}
-            renderCell={(row, key) => {
-              if (key === 'folio')
-                return (
-                  <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.folio ?? row.sale_id}</span>
-                );
-              if (key === 'date') return <span style={{ color: 'var(--text-secondary)' }}>{row.date}</span>;
-              if (key === 'amount')
-                return <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{money(row.amount)}</span>;
-              return row[key] ?? '—';
-            }}
-          />
-        </Card>
-      )}
+
+          {(sharedBreakdown ?? []).some((g) => g.total_count > 0) && (
+            <div className="z-2col">
+              {(sharedBreakdown ?? [])
+                .filter((g) => g.total_count > 0)
+                .map((group) => {
+                  const maxPersonRev = Math.max(...group.people.map((p) => p.revenue), 1);
+                  return (
+                    <Card
+                      key={group.provider_id}
+                      eyebrow="¿Quién atendió?"
+                      title={group.category}
+                      info="Estas cuentas las comparten varias personas; quién atendió se identifica por el nombre escrito en la nota de la cita (ej. 'Atiende Chio'). Los servicios cuya nota no menciona a nadie conocido quedan como No asignados."
+                    >
+                      {group.people.map((p, i) => (
+                        <RankRow
+                          key={p.name}
+                          rank={i + 1}
+                          label={p.name}
+                          sublabel={p.count + ' servicios'}
+                          value={money(p.revenue)}
+                          ratio={p.revenue / maxPersonRev}
+                          color={p.name === 'No asignados' ? 'var(--chart-compare)' : CHART[i % CHART.length]}
+                          last={i === group.people.length - 1}
+                        />
+                      ))}
+                    </Card>
+                  );
+                })}
+            </div>
+          )}
+
+          <Card eyebrow="Servicios" title="Volumen por persona">
+            <BarChart
+              data={staff.map((s) => ({ label: s.name.split(' ')[0], value: s.appts, color: s.color }))}
+              height={200}
+              yFormat={(v) => String(Math.round(v))}
+            />
+          </Card>
+
+          <Card eyebrow="Detalle" title="Ranking del equipo">
+            <DataTable
+              columns={COLUMNS}
+              rows={staff}
+              renderCell={(row, key, ri) => {
+                if (key === 'rank')
+                  return <span style={{ color: 'var(--text-muted)', fontWeight: 600 }}>{(ri ?? 0) + 1}</span>;
+                if (key === 'name')
+                  return (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <Avatar name={row.name} size="sm" tone={ri === 0 ? 'rose' : ri === 1 ? 'lavender' : 'ink'} />
+                      <span style={{ fontWeight: 'var(--fw-medium)', color: 'var(--text-heading)' }}>{row.name}</span>
+                    </div>
+                  );
+                if (key === 'appts') return row.appts;
+                if (key === 'recurring')
+                  return row.recurringClients != null ? (
+                    <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{row.recurringClients}</span>
+                  ) : (
+                    '—'
+                  );
+                if (key === 'avg') return money(row.avg);
+                if (key === 'rev')
+                  return <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{money(row.rev)}</span>;
+                return row[key] ?? '—';
+              }}
+            />
+          </Card>
+
+          {unassigned?.count > 0 && (
+            <Card
+              eyebrow="Sin profesional"
+              title="Servicios no asignados"
+              info="Servicios cobrados sin profesional asignado en AgendaPro (diseños, cejas, extras de walk-in). Cuentan en los ingresos totales pero no aparecen en el ranking del equipo porque no hay a quién atribuirlos."
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 24,
+                  marginBottom: 12,
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                <span>
+                  Total: <strong style={{ color: 'var(--text-display)' }}>{money(unassigned.revenue)}</strong>
+                </span>
+                <span>
+                  Servicios: <strong style={{ color: 'var(--text-display)' }}>{unassigned.count}</strong>
+                </span>
+              </div>
+              <DataTable
+                columns={UNASSIGNED_COLUMNS}
+                rows={unassigned.items}
+                renderCell={(row, key) => {
+                  if (key === 'folio')
+                    return (
+                      <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.folio ?? row.sale_id}</span>
+                    );
+                  if (key === 'date') return <span style={{ color: 'var(--text-secondary)' }}>{row.date}</span>;
+                  if (key === 'amount')
+                    return <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{money(row.amount)}</span>;
+                  return row[key] ?? '—';
+                }}
+              />
+            </Card>
+          )}
         </>
       )}
     </div>

--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { api } from '../lib/api';
 import { useApi } from '../hooks/use-api';
 import StatCard from '../components/widgets/stat-card';
@@ -9,6 +9,8 @@ import Donut from '../components/charts/donut';
 import BarChart from '../components/charts/bar-chart';
 import DataTable from '../components/widgets/data-table';
 import Avatar from '../components/ui/avatar';
+import SegmentedControl from '../components/ui/segmented-control';
+import StaffHoursPanel from '../components/widgets/staff-hours-panel';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
@@ -30,6 +32,7 @@ const UNASSIGNED_COLUMNS = [
 ];
 
 const Staff = ({ dateRange }) => {
+  const [tab, setTab] = useState('performance');
   const deps = [dateRange.from_date, dateRange.to_date];
   const { data: staffData } = useApi(() => api.staffPerformance(dateRange), deps);
   const { data: repeatData } = useApi(() => api.staffRepeatRate(dateRange), deps);
@@ -63,6 +66,19 @@ const Staff = ({ dateRange }) => {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
+      <SegmentedControl
+        value={tab}
+        onChange={setTab}
+        options={[
+          { value: 'performance', label: 'Desempeño' },
+          { value: 'hours', label: 'Horas' },
+        ]}
+      />
+
+      {tab === 'hours' && <StaffHoursPanel />}
+
+      {tab === 'performance' && (
+        <>
       <div className="z-kpi-grid">
         <StatCard
           label="Top empleada"
@@ -282,6 +298,8 @@ const Staff = ({ dateRange }) => {
             }}
           />
         </Card>
+      )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- New "Horas" tab in Personal: balance card per manicurista (net minutos owed/owing + "desde cuándo"), a time-entry ledger with a minutos/horas/días unit selector, and a vacation section (cupo anual editable, días tomados/solicitados con fecha) — replaces the manual tiempo-extra Google Sheet
- Notification bell in the topbar polling `/alerts` every 60s: pending WhatsApp reminders, upcoming vacations, manicuristas owing hours 14+ days — clicking an item navigates to the relevant page

## Test plan
- [x] Verified bundle compiles with no errors after each change
- [x] Backend endpoints (staff-hours/*, /alerts) tested end-to-end against local DB with real historical data from the source Google Sheet — computed balances match the sheet's own totals exactly
- [ ] Manual click-through in browser (dev server running at localhost:3000) — pending user confirmation