### PR TITLE
fix: reminder sync now global — read shared backend state on mount

### DIFF
--- a/src/components/widgets/appointment-reminders.jsx
+++ b/src/components/widgets/appointment-reminders.jsx
@@ -92,8 +92,6 @@ function sampleDetalleCita() {
   return buildDetalleCita([{ time: '12:00', service_name: 'Manicure de prueba' }], dateStr);
 }
 
-const STORAGE_KEY = 'zenya.appointmentReminders.lastSync';
-
 const REMINDER_COLS = [
   { key: 'name', label: 'Clienta' },
   { key: 'phone', label: 'Teléfono' },
@@ -146,26 +144,30 @@ const AppointmentReminders = () => {
     loadTemplate();
   }, []);
 
-  // Restore the last sync from this browser so a page reload doesn't wipe the
-  // list — "ya enviado" status still comes fresh from the server either way,
-  // this just saves having to click "Sincronizar" again to see it.
-  useEffect(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
-      if (saved?.clients?.length) {
-        setTargetDate(saved.targetDate);
-        setClients(saved.clients);
-        setSynced(true);
-      }
-    } catch {
-      // ignore malformed/unavailable storage
-    }
-  }, []);
+  const mapClients = (rawClients) =>
+    (rawClients ?? []).map((c) => ({
+      ...c,
+      // A brand-new client's booking can sync before her client record does
+      // (separate daily syncs) — show something identifiable instead of "—".
+      name: [c.first_name, c.last_name].filter(Boolean).join(' ') || `Clienta nueva #${c.client_id}`,
+    }));
 
+  // Reads whatever the shared backend currently has — no AgendaPro pull, just
+  // the local (shared, MySQL-backed) state — so every browser shows the same
+  // list on load. Syncing from one device should be visible on every other
+  // device on refresh, not just cached per-browser via localStorage.
   useEffect(() => {
-    if (!synced) return;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ targetDate, clients }));
-  }, [synced, targetDate, clients]);
+    (async () => {
+      try {
+        const data = await api.appointmentReminders({ live_sync: false });
+        setTargetDate(data.target_date);
+        setClients(mapClients(data.clients));
+        setSynced(true);
+      } catch {
+        // leave unsynced — the manual "Sincronizar" button still works
+      }
+    })();
+  }, []);
 
   const handleSaveTemplate = async () => {
     setSavingTemplate(true);
@@ -193,13 +195,8 @@ const AppointmentReminders = () => {
     try {
       const currentTemplate = templateLoaded ? template : await loadTemplate();
       // Pulls fresh data from AgendaPro first, server-side — this call can take a while.
-      const data = await api.appointmentReminders();
-      const freshClients = (data.clients ?? []).map((c) => ({
-        ...c,
-        // A brand-new client's booking can sync before her client record does
-        // (separate daily syncs) — show something identifiable instead of "—".
-        name: [c.first_name, c.last_name].filter(Boolean).join(' ') || `Clienta nueva #${c.client_id}`,
-      }));
+      const data = await api.appointmentReminders({ live_sync: true });
+      const freshClients = mapClients(data.clients);
 
       // Anyone who was here before but isn't anymore got cancelled/moved off
       // tomorrow — the fresh list from the server already reflects that, we

--- a/src/components/widgets/reminder-campaign-panel.jsx
+++ b/src/components/widgets/reminder-campaign-panel.jsx
@@ -60,7 +60,6 @@ const ReminderCampaignPanel = ({
   syncButtonLabel,
   defaultTemplateName,
   defaultTemplateBody,
-  storageKey,
   emptyBeforeSyncText,
   emptyAfterSyncText,
   dismissable = false,
@@ -101,23 +100,28 @@ const ReminderCampaignPanel = ({
     // eslint-disable-next-line
   }, []);
 
+  const mapClients = (rawClients) =>
+    (rawClients ?? []).map((c) => ({
+      ...c,
+      name: [c.first_name, c.last_name].filter(Boolean).join(' ') || `Clienta nueva #${c.client_id}`,
+    }));
+
+  // Reads whatever the shared backend currently has — no AgendaPro pull, just
+  // the local (shared, MySQL-backed) state — so every browser shows the same
+  // list on load. Syncing from one device should be visible on every other
+  // device on refresh, not just cached per-browser via localStorage.
   useEffect(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem(storageKey) || 'null');
-      if (saved?.clients?.length) {
-        setClients(saved.clients);
+    (async () => {
+      try {
+        const data = await fetchClients({ live_sync: false });
+        setClients(mapClients(data.clients));
         setSynced(true);
+      } catch {
+        // leave unsynced — the manual "Sincronizar" button still works
       }
-    } catch {
-      // ignore malformed/unavailable storage
-    }
+    })();
     // eslint-disable-next-line
   }, []);
-
-  useEffect(() => {
-    if (!synced) return;
-    localStorage.setItem(storageKey, JSON.stringify({ clients }));
-  }, [synced, clients, storageKey]);
 
   const handleTestSend = () => {
     if (!template) return;
@@ -151,11 +155,8 @@ const ReminderCampaignPanel = ({
     setSyncMessage(null);
     try {
       const currentTemplate = templateLoaded ? template : await loadTemplate();
-      const data = await fetchClients();
-      const freshClients = (data.clients ?? []).map((c) => ({
-        ...c,
-        name: [c.first_name, c.last_name].filter(Boolean).join(' ') || `Clienta nueva #${c.client_id}`,
-      }));
+      const data = await fetchClients({ live_sync: true });
+      const freshClients = mapClients(data.clients);
 
       const previousIds = new Set(clients.map((c) => c.client_id));
       const newCount = freshClients.filter((c) => !previousIds.has(c.client_id)).length;

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -78,9 +78,9 @@ export const api = {
   updateWhatsappTemplate: (id, body) => put(`/whatsapp/templates/${id}`, body),
   createWhatsappSend: (body) => post('/whatsapp/campaign-sends', body),
   whatsappCampaignStatus: () => get('/whatsapp/campaign-status'),
-  appointmentReminders: () => get('/whatsapp/appointment-reminders'),
-  retouchReminders: () => get('/whatsapp/retouch-reminders'),
-  newClientFeedback: () => get('/whatsapp/new-client-feedback'),
+  appointmentReminders: (params) => get('/whatsapp/appointment-reminders', params),
+  retouchReminders: (params) => get('/whatsapp/retouch-reminders', params),
+  newClientFeedback: (params) => get('/whatsapp/new-client-feedback', params),
   dismissReminder: (body) => post('/whatsapp/dismissals', body),
   reminderEffectiveness: () => get('/whatsapp/reminder-effectiveness'),
 

--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -378,7 +378,6 @@ Esperamos que te encuentres muy bien ☺️ Te contactamos para recordarte que y
 ¿Te gustaría agendar tu cita? 🥰
 
 Será un placer atenderte 💕 Bonito día! ☺️`}
-        storageKey="zenya.retouchReminders.lastSync"
         emptyBeforeSyncText='Da clic en "Sincronizar clientas de retoque" para ver quién tiene retoque pendiente.'
         emptyAfterSyncText="No hay clientas con retoque pendiente hoy."
         dismissable
@@ -406,7 +405,6 @@ Si tienes un momento, nos encantaría que nos compartieras tu opinión sobre la 
 Tu experiencia es muy valiosa para nosotras y nos ayuda a seguir creando momentos especiales para cada persona que nos visita.
 
 ¡Gracias por tu confianza y por elegir Zenya! 💕`}
-        storageKey="zenya.newClientFeedback.lastSync"
         emptyBeforeSyncText='Da clic en "Sincronizar clientas nuevas de hoy" para ver quién visitó por primera vez.'
         emptyAfterSyncText="No hay clientas nuevas hoy."
         dismissable


### PR DESCRIPTION
## Summary
- Removed per-browser localStorage caching from the 3 reminder panels (recordatorios de mañana, retoque, clientas nuevas). Every browser now auto-loads the shared backend state on mount (`live_sync=false`, no AgendaPro pull) instead of its own local cache, so a sync done on one device shows up for everyone on refresh.
- Pairs with zenya-api PR #35 (already merged/deployed to stage), which adds the `live_sync` param and the same-day-send grace period.

## Test plan
- [x] Lint clean, bundle compiles
- [x] User tested locally in browser and confirmed the fix works