### PR TITLE
feat: pagination (Directorio, Retención, Reactivación, CLV) + multi-column sort

### DIFF
--- a/src/components/ui/pagination.jsx
+++ b/src/components/ui/pagination.jsx
@@ -1,0 +1,71 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Select from './select';
+import Button from './button';
+
+const PAGE_SIZE_OPTIONS = [
+  { value: '25', label: '25 por página' },
+  { value: '50', label: '50 por página' },
+  { value: '100', label: '100 por página' },
+];
+
+const Pagination = ({ page, totalPages, pageSize, onPageChange, onPageSizeChange, hasPrev, hasNext, rangeLabel }) => (
+  <div style={{ marginTop: 14, paddingTop: 14, borderTop: '1px solid var(--border-subtle)' }}>
+    <div
+      style={{
+        textAlign: 'right',
+        fontFamily: 'var(--font-sans)',
+        fontSize: 'var(--text-xs)',
+        color: 'var(--text-muted)',
+        marginBottom: 10,
+      }}
+    >
+      {rangeLabel ? `${rangeLabel} · ` : ''}
+      {totalPages != null ? `página ${page} de ${totalPages}` : `página ${page}`}
+    </div>
+
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flexWrap: 'wrap', gap: 14 }}>
+      <Button
+        variant="ghost"
+        size="sm"
+        iconLeft={ChevronLeft}
+        disabled={!hasPrev}
+        onClick={() => onPageChange(page - 1)}
+      >
+        Anterior
+      </Button>
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minWidth: 28,
+          padding: '2px 4px',
+          fontFamily: 'var(--font-sans)',
+          fontSize: 'var(--text-sm)',
+          fontWeight: 'var(--fw-semibold)',
+          color: 'var(--brand-primary)',
+          borderBottom: '2px solid var(--brand-primary)',
+        }}
+      >
+        {page}
+      </span>
+      <Button
+        variant="ghost"
+        size="sm"
+        iconRight={ChevronRight}
+        disabled={!hasNext}
+        onClick={() => onPageChange(page + 1)}
+      >
+        Siguiente
+      </Button>
+      <Select
+        size="sm"
+        value={String(pageSize)}
+        onChange={(v) => onPageSizeChange(Number(v))}
+        options={PAGE_SIZE_OPTIONS}
+      />
+    </div>
+  </div>
+);
+
+export default Pagination;

--- a/src/components/widgets/data-table.jsx
+++ b/src/components/widgets/data-table.jsx
@@ -17,40 +17,106 @@ const SortArrows = ({ dir }) => (
   </span>
 );
 
-const DataTable = ({ columns = [], rows = [], renderCell, style, onSortedRowsChange }) => {
-  const [sort, setSort] = useState(null); // { key, dir: 'asc' | 'desc' }
+function compareByRule(a, b, rule, columns) {
+  const col = columns.find((c) => c.key === rule.key);
+  if (!col) return 0;
+  const getValue = col.sortValue ?? ((row) => row[col.key]);
+  const va = getValue(a);
+  const vb = getValue(b);
+  if (va == null && vb == null) return 0;
+  if (va == null) return 1; // nulls always last, regardless of direction
+  if (vb == null) return -1;
+  const factor = rule.dir === 'asc' ? 1 : -1;
+  if (typeof va === 'string' || typeof vb === 'string') return String(va).localeCompare(String(vb), 'es') * factor;
+  return (va - vb) * factor;
+}
+
+// maxSortKeys=1 (default) is the original single-column behavior: click
+// cycles desc → asc → cleared, and clicking a different column replaces it.
+// maxSortKeys>1 lets multiple columns stay active at once, in click order —
+// click an unsorted column to add it as the next-priority rule (bumping the
+// lowest-priority rule out once at capacity); click an already-active column
+// to cycle its direction in place, clearing it (and shifting the rest up)
+// on the third click.
+const DataTable = ({
+  columns = [],
+  rows = [],
+  renderCell,
+  style,
+  onSortedRowsChange,
+  onSortChange,
+  page,
+  pageSize,
+  maxSortKeys = 1,
+}) => {
+  const multi = maxSortKeys > 1;
+  const [sort, setSort] = useState(multi ? [] : null);
 
   const handleHeaderClick = (col) => {
     if (!col.sortable) return;
+    if (!multi) {
+      setSort((prev) => {
+        if (prev?.key !== col.key) return { key: col.key, dir: 'desc' };
+        if (prev.dir === 'desc') return { key: col.key, dir: 'asc' };
+        return null; // third click restores original order
+      });
+      return;
+    }
     setSort((prev) => {
-      if (prev?.key !== col.key) return { key: col.key, dir: 'desc' };
-      if (prev.dir === 'desc') return { key: col.key, dir: 'asc' };
-      return null; // third click restores original order
+      const list = prev ?? [];
+      const idx = list.findIndex((r) => r.key === col.key);
+      if (idx === -1) {
+        const next = [...list, { key: col.key, dir: 'desc' }];
+        if (next.length > maxSortKeys) {
+          // keep the higher-priority rules intact, replace the lowest-priority slot
+          return [...next.slice(0, maxSortKeys - 1), { key: col.key, dir: 'desc' }];
+        }
+        return next;
+      }
+      if (list[idx].dir === 'desc') {
+        return list.map((r, i) => (i === idx ? { ...r, dir: 'asc' } : r));
+      }
+      return list.filter((_, i) => i !== idx); // third click on this column clears it
     });
   };
 
-  const sortedRows = useMemo(() => {
-    if (!sort) return rows;
-    const col = columns.find((c) => c.key === sort.key);
-    if (!col) return rows;
-    const getValue = col.sortValue ?? ((row) => row[col.key]);
-    const factor = sort.dir === 'asc' ? 1 : -1;
-    return [...rows].sort((a, b) => {
-      const va = getValue(a);
-      const vb = getValue(b);
-      if (va == null && vb == null) return 0;
-      if (va == null) return 1; // nulls always last
-      if (vb == null) return -1;
-      if (typeof va === 'string' || typeof vb === 'string') return String(va).localeCompare(String(vb), 'es') * factor;
-      return (va - vb) * factor;
-    });
-  }, [rows, columns, sort]);
+  useEffect(() => {
+    onSortChange?.(sort);
+    // eslint-disable-next-line
+  }, [sort]);
 
-  // Lets parent components (e.g. an export button) mirror exactly what's
-  // rendered, including the current sort order.
+  const sortedRows = useMemo(() => {
+    const rules = multi ? sort : sort ? [sort] : [];
+    if (!rules.length) return rows;
+    return [...rows].sort((a, b) => {
+      for (const rule of rules) {
+        const cmp = compareByRule(a, b, rule, columns);
+        if (cmp !== 0) return cmp;
+      }
+      return 0;
+    });
+  }, [rows, columns, sort, multi]);
+
+  // Lets parent components (e.g. an export button) mirror the full sorted
+  // set, independent of the current page — export should never be limited
+  // to what's currently visible on screen.
   useEffect(() => {
     onSortedRowsChange?.(sortedRows);
   }, [sortedRows]);
+
+  // Pagination (optional) slices for display only, after sorting — it never
+  // affects onSortedRowsChange above.
+  const displayRows = useMemo(() => {
+    if (page == null || pageSize == null) return sortedRows;
+    const start = (page - 1) * pageSize;
+    return sortedRows.slice(start, start + pageSize);
+  }, [sortedRows, page, pageSize]);
+
+  const sortInfo = (col) => {
+    if (!multi) return sort?.key === col.key ? { dir: sort.dir, priority: null } : null;
+    const idx = (sort ?? []).findIndex((r) => r.key === col.key);
+    return idx === -1 ? null : { dir: sort[idx].dir, priority: sort.length > 1 ? idx + 1 : null };
+  };
 
   return (
     <div style={{ overflowX: 'auto', ...style }}>
@@ -64,34 +130,56 @@ const DataTable = ({ columns = [], rows = [], renderCell, style, onSortedRowsCha
       >
         <thead>
           <tr>
-            {columns.map((col) => (
-              <th
-                key={col.key}
-                onClick={() => handleHeaderClick(col)}
-                title={col.sortable ? 'Ordenar' : undefined}
-                style={{
-                  textAlign: col.align || 'left',
-                  padding: '8px 12px',
-                  fontSize: 'var(--text-xs)',
-                  fontWeight: 'var(--fw-semibold)',
-                  letterSpacing: 'var(--ls-label)',
-                  textTransform: 'uppercase',
-                  color: sort?.key === col.key ? 'var(--text-brand)' : 'var(--text-muted)',
-                  borderBottom: '1px solid var(--border-subtle)',
-                  whiteSpace: col.nowrap ? 'nowrap' : undefined,
-                  background: 'var(--surface-sunken)',
-                  cursor: col.sortable ? 'pointer' : undefined,
-                  userSelect: col.sortable ? 'none' : undefined,
-                }}
-              >
-                {col.label}
-                {col.sortable && <SortArrows dir={sort?.key === col.key ? sort.dir : null} />}
-              </th>
-            ))}
+            {columns.map((col) => {
+              const info = sortInfo(col);
+              return (
+                <th
+                  key={col.key}
+                  onClick={() => handleHeaderClick(col)}
+                  title={
+                    col.sortable
+                      ? multi
+                        ? 'Clic para ordenar por esta columna; clic en otra para agregarla como siguiente criterio (hasta 3); clic 3 veces para quitarla'
+                        : 'Ordenar'
+                      : undefined
+                  }
+                  style={{
+                    textAlign: col.align || 'left',
+                    padding: '8px 12px',
+                    fontSize: 'var(--text-xs)',
+                    fontWeight: 'var(--fw-semibold)',
+                    letterSpacing: 'var(--ls-label)',
+                    textTransform: 'uppercase',
+                    color: info ? 'var(--text-brand)' : 'var(--text-muted)',
+                    borderBottom: '1px solid var(--border-subtle)',
+                    whiteSpace: col.nowrap ? 'nowrap' : undefined,
+                    background: 'var(--surface-sunken)',
+                    cursor: col.sortable ? 'pointer' : undefined,
+                    userSelect: col.sortable ? 'none' : undefined,
+                  }}
+                >
+                  {col.label}
+                  {col.sortable && <SortArrows dir={info?.dir ?? null} />}
+                  {info?.priority && (
+                    <span
+                      style={{
+                        marginLeft: 4,
+                        fontSize: 9,
+                        fontWeight: 700,
+                        color: 'var(--text-brand)',
+                        verticalAlign: 'super',
+                      }}
+                    >
+                      {info.priority}
+                    </span>
+                  )}
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>
-          {sortedRows.map((row, rowIndex) => (
+          {displayRows.map((row, rowIndex) => (
             <tr key={rowIndex} className="z-row">
               {columns.map((col) => (
                 <td
@@ -99,7 +187,7 @@ const DataTable = ({ columns = [], rows = [], renderCell, style, onSortedRowsCha
                   style={{
                     textAlign: col.align || 'left',
                     padding: '10px 12px',
-                    borderBottom: rowIndex < sortedRows.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+                    borderBottom: rowIndex < displayRows.length - 1 ? '1px solid var(--border-subtle)' : 'none',
                     color: 'var(--text-body)',
                     whiteSpace: col.nowrap ? 'nowrap' : undefined,
                     verticalAlign: 'middle',

--- a/src/components/widgets/reactivation-panel.jsx
+++ b/src/components/widgets/reactivation-panel.jsx
@@ -2,12 +2,14 @@ import { useState, useMemo } from 'react';
 import { MessageCircle, Plus, Edit2, Archive, Send } from 'lucide-react';
 import { api } from '../../lib/api';
 import { useApi } from '../../hooks/use-api';
+import { usePagination } from '../../hooks/use-pagination';
 import { buildWhatsappUrl, TEST_RECIPIENTS } from '../../lib/whatsapp';
 import Card from '../ui/card';
 import Badge from '../ui/badge';
 import Button from '../ui/button';
 import IconButton from '../ui/icon-button';
 import Avatar from '../ui/avatar';
+import Pagination from '../ui/pagination';
 import DataTable from './data-table';
 import StatCard from './stat-card';
 
@@ -155,6 +157,9 @@ function campaignRank(send) {
   return send.reactivated ? 2 : 1;
 }
 
+// Click a header to sort by it (asc/desc toggle); click another to add it as
+// the next-priority criterion — up to 3 at once — without losing the first.
+// A small superscript number marks each column's priority once 2+ are active.
 const CANDIDATE_COLS = [
   {
     key: 'name',
@@ -181,6 +186,7 @@ const ReactivationPanel = ({ profiles }) => {
   const [selectedTemplateByClient, setSelectedTemplateByClient] = useState({});
   const [testRecipientByTemplate, setTestRecipientByTemplate] = useState({});
   const [candidateSearch, setCandidateSearch] = useState('');
+  const [sortSignal, setSortSignal] = useState(null);
 
   const { data: templates } = useApi(() => api.whatsappTemplates({ category: 'reactivation' }), [refreshKey]);
   const { data: campaignStatus } = useApi(() => api.whatsappCampaignStatus(), [refreshKey]);
@@ -231,6 +237,11 @@ const ReactivationPanel = ({ profiles }) => {
       return name.includes(q) || (c.phone ?? '').toLowerCase().includes(q);
     });
   }, [candidates, candidateSearch]);
+
+  // DataTable does the actual multi-column sort internally (maxSortKeys={3}
+  // below); onSortChange just gives us a signal to reset back to page 1
+  // whenever the active sort changes.
+  const candidatesPagination = usePagination(filteredCandidates.length, 50, `${candidateSearch}|${sortSignal}`);
 
   const stats = useMemo(() => {
     const contacted = candidates.filter((c) => c.latestSend).length;
@@ -409,7 +420,7 @@ const ReactivationPanel = ({ profiles }) => {
       <Card
         eyebrow="Reactivación"
         title="Clientas en riesgo o perdidas"
-        info="Clientas con 45+ días sin visitar (más las que ya contactaste antes, aunque hayan vuelto). Elige una plantilla y da clic en el ícono de WhatsApp para abrir el chat con el mensaje listo. Haz clic en los encabezados para ordenar."
+        info="Clientas con 45+ días sin visitar (más las que ya contactaste antes, aunque hayan vuelto). Elige una plantilla y da clic en el ícono de WhatsApp para abrir el chat con el mensaje listo. Haz clic en un encabezado para ordenar por esa columna; haz clic en otra para agregarla como siguiente criterio (hasta 3, sin perder la anterior) — un número junto a la flecha marca la prioridad."
         action={
           <input
             placeholder="Buscar por nombre o teléfono..."
@@ -420,67 +431,83 @@ const ReactivationPanel = ({ profiles }) => {
         }
       >
         {filteredCandidates.length > 0 ? (
-          <DataTable
-            columns={CANDIDATE_COLS}
-            rows={filteredCandidates}
-            renderCell={(row, key) => {
-              if (key === 'name') {
-                const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
-                return (
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                    <Avatar name={name} size="sm" tone="ink" />
-                    <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{name}</span>
-                  </div>
-                );
-              }
-              if (key === 'phone') return <span style={{ color: 'var(--text-secondary)' }}>{row.phone ?? '—'}</span>;
-              if (key === 'days_since')
-                return row.days_since_last != null ? (
-                  <span style={{ color: 'var(--text-body)' }}>{row.days_since_last} d</span>
-                ) : (
-                  <span style={{ color: 'var(--text-muted)' }}>—</span>
-                );
-              if (key === 'estado') return estadoBadge(row.churn_status);
-              if (key === 'campana') return campaignCell(row.latestSend);
-              if (key === 'accion') {
-                const hasTemplates = (templates ?? []).length > 0;
-                return (
-                  <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end', alignItems: 'center' }}>
-                    {(templates ?? []).length > 1 && (
-                      <select
-                        value={selectedTemplateByClient[row.client_id] ?? templates[0]?.id}
-                        onChange={(e) =>
-                          setSelectedTemplateByClient((prev) => ({ ...prev, [row.client_id]: e.target.value }))
+          <>
+            <DataTable
+              columns={CANDIDATE_COLS}
+              rows={filteredCandidates}
+              maxSortKeys={3}
+              onSortChange={(s) => setSortSignal(JSON.stringify(s))}
+              page={candidatesPagination.page}
+              pageSize={candidatesPagination.pageSize}
+              renderCell={(row, key) => {
+                if (key === 'name') {
+                  const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
+                  return (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <Avatar name={name} size="sm" tone="ink" />
+                      <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{name}</span>
+                    </div>
+                  );
+                }
+                if (key === 'phone') return <span style={{ color: 'var(--text-secondary)' }}>{row.phone ?? '—'}</span>;
+                if (key === 'days_since')
+                  return row.days_since_last != null ? (
+                    <span style={{ color: 'var(--text-body)' }}>{row.days_since_last} d</span>
+                  ) : (
+                    <span style={{ color: 'var(--text-muted)' }}>—</span>
+                  );
+                if (key === 'estado') return estadoBadge(row.churn_status);
+                if (key === 'campana') return campaignCell(row.latestSend);
+                if (key === 'accion') {
+                  const hasTemplates = (templates ?? []).length > 0;
+                  return (
+                    <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end', alignItems: 'center' }}>
+                      {(templates ?? []).length > 1 && (
+                        <select
+                          value={selectedTemplateByClient[row.client_id] ?? templates[0]?.id}
+                          onChange={(e) =>
+                            setSelectedTemplateByClient((prev) => ({ ...prev, [row.client_id]: e.target.value }))
+                          }
+                          style={{ ...inputStyle, padding: '4px 8px', height: 30, fontSize: 'var(--text-xs)' }}
+                        >
+                          {templates.map((t) => (
+                            <option key={t.id} value={t.id}>
+                              {t.name}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                      <IconButton
+                        icon={MessageCircle}
+                        size="sm"
+                        variant="soft"
+                        title={
+                          !row.phone
+                            ? 'Sin teléfono'
+                            : !hasTemplates
+                              ? 'Crea una plantilla primero'
+                              : 'Enviar por WhatsApp'
                         }
-                        style={{ ...inputStyle, padding: '4px 8px', height: 30, fontSize: 'var(--text-xs)' }}
-                      >
-                        {templates.map((t) => (
-                          <option key={t.id} value={t.id}>
-                            {t.name}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                    <IconButton
-                      icon={MessageCircle}
-                      size="sm"
-                      variant="soft"
-                      title={
-                        !row.phone
-                          ? 'Sin teléfono'
-                          : !hasTemplates
-                            ? 'Crea una plantilla primero'
-                            : 'Enviar por WhatsApp'
-                      }
-                      disabled={!row.phone || !hasTemplates}
-                      onClick={() => handleSend(row)}
-                    />
-                  </div>
-                );
-              }
-              return row[key] ?? '—';
-            }}
-          />
+                        disabled={!row.phone || !hasTemplates}
+                        onClick={() => handleSend(row)}
+                      />
+                    </div>
+                  );
+                }
+                return row[key] ?? '—';
+              }}
+            />
+            <Pagination
+              page={candidatesPagination.page}
+              totalPages={candidatesPagination.totalPages}
+              pageSize={candidatesPagination.pageSize}
+              hasPrev={candidatesPagination.hasPrev}
+              hasNext={candidatesPagination.hasNext}
+              rangeLabel={candidatesPagination.rangeLabel}
+              onPageChange={candidatesPagination.setPage}
+              onPageSizeChange={candidatesPagination.setPageSize}
+            />
+          </>
         ) : (
           <EmptyState
             text={

--- a/src/hooks/use-pagination.js
+++ b/src/hooks/use-pagination.js
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+// Bookkeeping only (page/pageSize/counts) — callers decide how to use it.
+// For client-side tables backed by DataTable, pass page/pageSize straight
+// through to DataTable's own page/pageSize props so slicing happens *after*
+// its internal column sort. For server-side pagination, use page/pageSize to
+// compute an offset for the API call instead.
+export function usePagination(totalItems, defaultPageSize, resetSignal) {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(defaultPageSize);
+
+  // Any time the underlying set changes shape (new filter/search/sort target,
+  // or a resize of the page), snap back to page 1 instead of risking landing
+  // on a now out-of-range page.
+  useEffect(() => {
+    setPage(1);
+    // eslint-disable-next-line
+  }, [totalItems, pageSize, resetSignal]);
+
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  const clampedPage = Math.min(page, totalPages);
+  const start = (clampedPage - 1) * pageSize;
+  const rangeLabel = totalItems ? `${start + 1}–${Math.min(start + pageSize, totalItems)} de ${totalItems}` : null;
+
+  return {
+    page: clampedPage,
+    pageSize,
+    setPage,
+    setPageSize,
+    totalPages,
+    hasPrev: clampedPage > 1,
+    hasNext: clampedPage < totalPages,
+    rangeLabel,
+  };
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -63,6 +63,7 @@ export const api = {
   salesSummary: (params) => get('/sales/summary', params),
   bookings: (params) => get('/bookings', params),
   clients: (params) => get('/clients', params),
+  clientsCount: (params) => get('/clients/count', params),
   professionals: () => get('/professionals'),
   services: () => get('/services'),
   businessProfile: () => get('/business-profile'),

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -14,6 +14,8 @@ import Button from '../components/ui/button';
 import Select from '../components/ui/select';
 import SegmentedControl from '../components/ui/segmented-control';
 import InfoTip from '../components/ui/info-tip';
+import Pagination from '../components/ui/pagination';
+import { usePagination } from '../hooks/use-pagination';
 import ReactivationPanel from '../components/widgets/reactivation-panel';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
@@ -170,7 +172,31 @@ const Clients = ({ dateRange }) => {
   const { data: kpis } = useApi(() => api.kpis(dateRange), deps);
   const { data: retention } = useApi(() => api.clientRetention(dateRange), deps);
   const { data: stats } = useApi(() => api.clientStats(dateRange), deps);
-  const { data: clients, loading } = useApi(() => api.clients({ search: search || undefined, limit: 100 }), [search]);
+
+  // Directorio paginates server-side — the API enforces its own limit/offset
+  // and the full client list is too large to fetch all at once. The total
+  // count comes from a separate lightweight endpoint (same search filter)
+  // so "página X de Y" and the "1–25 de N" range match the other tables.
+  const [directorioPage, setDirectorioPage] = useState(1);
+  const [directorioPageSize, setDirectorioPageSize] = useState(25);
+  const directorioOffset = (directorioPage - 1) * directorioPageSize;
+  const { data: clients, loading } = useApi(
+    () => api.clients({ search: search || undefined, limit: directorioPageSize, offset: directorioOffset }),
+    [search, directorioPage, directorioPageSize]
+  );
+  const { data: directorioCountData } = useApi(() => api.clientsCount({ search: search || undefined }), [search]);
+  const directorioTotal = directorioCountData?.count ?? null;
+  const directorioTotalPages =
+    directorioTotal != null ? Math.max(1, Math.ceil(directorioTotal / directorioPageSize)) : null;
+  const directorioHasNext =
+    directorioTotal != null
+      ? directorioOffset + directorioPageSize < directorioTotal
+      : (clients?.length ?? 0) === directorioPageSize;
+  const directorioRangeLabel =
+    directorioTotal != null && (clients?.length ?? 0) > 0
+      ? `${directorioOffset + 1}–${Math.min(directorioOffset + directorioPageSize, directorioTotal)} de ${directorioTotal}`
+      : null;
+
   const { data: profilesData } = useApi(() => api.clientProfiles(dateRange), deps);
   const { data: clvData } = useApi(() => api.clvSegments(dateRange), deps);
 
@@ -222,6 +248,8 @@ const Clients = ({ dateRange }) => {
     }
     return rows;
   }, [retentionProfiles, statusFilter, retentionSearch]);
+
+  const retentionPagination = usePagination(filteredRetentionProfiles.length, 25, `${statusFilter}|${retentionSearch}`);
 
   const exportRetentionToExcel = async () => {
     const workbook = new ExcelJS.Workbook();
@@ -290,6 +318,7 @@ const Clients = ({ dateRange }) => {
     () => (clvSegmentFilter ? vipClients.filter((c) => c.segment === clvSegmentFilter) : vipClients),
     [vipClients, clvSegmentFilter]
   );
+  const clvPagination = usePagination(filteredVipClients.length, 25, clvSegmentFilter);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
@@ -407,12 +436,15 @@ const Clients = ({ dateRange }) => {
           <Card
             eyebrow="Directorio"
             title="Clientes"
-            info="Todas las clientas registradas en AgendaPro, hayan comprado o no. Este directorio no depende del periodo seleccionado. Se muestran hasta 100 resultados; usa el buscador para encontrar a alguien."
+            info="Todas las clientas registradas en AgendaPro, hayan comprado o no. Este directorio no depende del periodo seleccionado. Usa el buscador para encontrar a alguien o navega con la paginación."
             action={
               <input
                 placeholder="Buscar..."
                 value={search}
-                onChange={(e) => setSearch(e.target.value)}
+                onChange={(e) => {
+                  setSearch(e.target.value);
+                  setDirectorioPage(1);
+                }}
                 style={{
                   padding: '4px 10px',
                   borderRadius: 6,
@@ -457,6 +489,21 @@ const Clients = ({ dateRange }) => {
                       </div>
                     );
                   return row[key] ?? '—';
+                }}
+              />
+            )}
+            {!loading && (clients?.length ?? 0) > 0 && (
+              <Pagination
+                page={directorioPage}
+                totalPages={directorioTotalPages}
+                pageSize={directorioPageSize}
+                hasPrev={directorioPage > 1}
+                hasNext={directorioHasNext}
+                rangeLabel={directorioRangeLabel}
+                onPageChange={setDirectorioPage}
+                onPageSizeChange={(v) => {
+                  setDirectorioPageSize(v);
+                  setDirectorioPage(1);
                 }}
               />
             )}
@@ -566,50 +613,64 @@ const Clients = ({ dateRange }) => {
             }
           >
             {filteredRetentionProfiles.length > 0 ? (
-              <DataTable
-                columns={RETENTION_COLS}
-                rows={filteredRetentionProfiles}
-                onSortedRowsChange={setRetentionSortedRows}
-                renderCell={(row, key) => {
-                  if (key === 'name') {
-                    const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
-                    return (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                        <Avatar name={name} size="sm" tone="ink" />
-                        <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{name}</span>
-                      </div>
-                    );
-                  }
-                  if (key === 'phone')
-                    return <span style={{ color: 'var(--text-secondary)' }}>{row.phone ?? '—'}</span>;
-                  if (key === 'last_visit')
-                    return <span style={{ color: 'var(--text-secondary)' }}>{row.last_visit ?? '—'}</span>;
-                  if (key === 'days_since') {
-                    const d = row.days_since_last ?? 0;
-                    return (
-                      <span
-                        style={{
-                          fontWeight: 600,
-                          color: d > 90 ? 'var(--negative)' : d > 45 ? 'var(--caution)' : 'var(--text-body)',
-                        }}
-                      >
-                        {d} d
-                      </span>
-                    );
-                  }
-                  if (key === 'avg_frequency')
-                    return <span style={{ color: 'var(--text-secondary)' }}>{row.avg_frequency ?? '—'}</span>;
-                  if (key === 'churn_status') return estadoBadge(row.churn_status);
-                  if (key === 'lifetime_revenue') return money(row.lifetime_revenue ?? 0);
-                  if (key === 'estimated_lost')
-                    return row.estimated_lost ? (
-                      <span style={{ fontWeight: 600, color: 'var(--negative)' }}>{money(row.estimated_lost)}</span>
-                    ) : (
-                      <span style={{ color: 'var(--text-muted)' }}>—</span>
-                    );
-                  return row[key] ?? '—';
-                }}
-              />
+              <>
+                <DataTable
+                  columns={RETENTION_COLS}
+                  rows={filteredRetentionProfiles}
+                  onSortedRowsChange={setRetentionSortedRows}
+                  page={retentionPagination.page}
+                  pageSize={retentionPagination.pageSize}
+                  renderCell={(row, key) => {
+                    if (key === 'name') {
+                      const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || '—';
+                      return (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                          <Avatar name={name} size="sm" tone="ink" />
+                          <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{name}</span>
+                        </div>
+                      );
+                    }
+                    if (key === 'phone')
+                      return <span style={{ color: 'var(--text-secondary)' }}>{row.phone ?? '—'}</span>;
+                    if (key === 'last_visit')
+                      return <span style={{ color: 'var(--text-secondary)' }}>{row.last_visit ?? '—'}</span>;
+                    if (key === 'days_since') {
+                      const d = row.days_since_last ?? 0;
+                      return (
+                        <span
+                          style={{
+                            fontWeight: 600,
+                            color: d > 90 ? 'var(--negative)' : d > 45 ? 'var(--caution)' : 'var(--text-body)',
+                          }}
+                        >
+                          {d} d
+                        </span>
+                      );
+                    }
+                    if (key === 'avg_frequency')
+                      return <span style={{ color: 'var(--text-secondary)' }}>{row.avg_frequency ?? '—'}</span>;
+                    if (key === 'churn_status') return estadoBadge(row.churn_status);
+                    if (key === 'lifetime_revenue') return money(row.lifetime_revenue ?? 0);
+                    if (key === 'estimated_lost')
+                      return row.estimated_lost ? (
+                        <span style={{ fontWeight: 600, color: 'var(--negative)' }}>{money(row.estimated_lost)}</span>
+                      ) : (
+                        <span style={{ color: 'var(--text-muted)' }}>—</span>
+                      );
+                    return row[key] ?? '—';
+                  }}
+                />
+                <Pagination
+                  page={retentionPagination.page}
+                  totalPages={retentionPagination.totalPages}
+                  pageSize={retentionPagination.pageSize}
+                  hasPrev={retentionPagination.hasPrev}
+                  hasNext={retentionPagination.hasNext}
+                  rangeLabel={retentionPagination.rangeLabel}
+                  onPageChange={retentionPagination.setPage}
+                  onPageSizeChange={retentionPagination.setPageSize}
+                />
+              </>
             ) : (
               <div
                 style={{
@@ -788,41 +849,55 @@ const Clients = ({ dateRange }) => {
             }
           >
             {filteredVipClients.length > 0 ? (
-              <DataTable
-                columns={VIP_COLS}
-                rows={filteredVipClients}
-                renderCell={(row, key) => {
-                  if (key === 'name') {
-                    const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || row.name || '—';
-                    return (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                        <Avatar name={name} size="sm" tone="rose" />
-                        <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{name}</span>
-                      </div>
-                    );
-                  }
-                  if (key === 'segment') {
-                    const seg = row.segment ?? '—';
-                    return (
-                      <Badge tone={SEG_TONE[seg] ?? 'neutral'} size="sm" dot>
-                        {seg}
-                      </Badge>
-                    );
-                  }
-                  if (key === 'lifetime_revenue')
-                    return (
-                      <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>
-                        {money(row.lifetime_revenue ?? 0)}
-                      </span>
-                    );
-                  if (key === 'avg_ticket') return money(row.avg_ticket ?? 0);
-                  if (key === 'last_visit')
-                    return <span style={{ color: 'var(--text-secondary)' }}>{row.last_visit ?? '—'}</span>;
-                  if (key === 'days_since')
-                    return <span style={{ color: 'var(--text-secondary)' }}>{row.days_since_last ?? '—'} d</span>;
-                  return row[key] ?? '—';
-                }}
-              />
+              <>
+                <DataTable
+                  columns={VIP_COLS}
+                  rows={filteredVipClients}
+                  page={clvPagination.page}
+                  pageSize={clvPagination.pageSize}
+                  renderCell={(row, key) => {
+                    if (key === 'name') {
+                      const name = [row.first_name, row.last_name].filter(Boolean).join(' ') || row.name || '—';
+                      return (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                          <Avatar name={name} size="sm" tone="rose" />
+                          <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{name}</span>
+                        </div>
+                      );
+                    }
+                    if (key === 'segment') {
+                      const seg = row.segment ?? '—';
+                      return (
+                        <Badge tone={SEG_TONE[seg] ?? 'neutral'} size="sm" dot>
+                          {seg}
+                        </Badge>
+                      );
+                    }
+                    if (key === 'lifetime_revenue')
+                      return (
+                        <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>
+                          {money(row.lifetime_revenue ?? 0)}
+                        </span>
+                      );
+                    if (key === 'avg_ticket') return money(row.avg_ticket ?? 0);
+                    if (key === 'last_visit')
+                      return <span style={{ color: 'var(--text-secondary)' }}>{row.last_visit ?? '—'}</span>;
+                    if (key === 'days_since')
+                      return <span style={{ color: 'var(--text-secondary)' }}>{row.days_since_last ?? '—'} d</span>;
+                    return row[key] ?? '—';
+                  }}
+                />
+                <Pagination
+                  page={clvPagination.page}
+                  totalPages={clvPagination.totalPages}
+                  pageSize={clvPagination.pageSize}
+                  hasPrev={clvPagination.hasPrev}
+                  hasNext={clvPagination.hasNext}
+                  rangeLabel={clvPagination.rangeLabel}
+                  onPageChange={clvPagination.setPage}
+                  onPageSizeChange={clvPagination.setPageSize}
+                />
+              </>
             ) : (
               <div
                 style={{


### PR DESCRIPTION
## Summary
- New shared `Pagination` control (25/50/100 per page, Anterior/Siguiente) + `usePagination` hook, wired into Directorio (default 25, server-side against `/clients/count`), Retención (default 25), Reactivación (default 50), and CLV & Segmentos (default 25) — all client-side except Directorio.
- `DataTable` gains an opt-in `maxSortKeys` prop for multi-column click-sort: click a header to sort by it, click another to add it as the next priority (up to 3) without losing the first, click a column 3x to clear it. Only Reactivación uses `maxSortKeys={3}`; every other table is unaffected (default stays single-column).

## Test plan
- [x] Lint clean, bundle compiles
- [x] User tested locally in browser and confirmed both the pagination display and the multi-column sort work as expected