### PR TITLE
fix: gastos sync now targets the month selected in the Gastos page

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -9,8 +9,10 @@ async function get(path, params = {}) {
   return res.json();
 }
 
-async function post(path, body) {
-  const res = await fetch(`${BASE_URL}${path}`, {
+async function post(path, body, params) {
+  const url = new URL(`${BASE_URL}${path}`);
+  if (params) Object.entries(params).forEach(([k, v]) => v != null && url.searchParams.set(k, v));
+  const res = await fetch(url.toString(), {
     method: 'POST',
     headers: { 'X-API-Key': API_KEY, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -51,7 +53,7 @@ export const api = {
   unassignedServices: (params) => get('/analytics/unassigned-services', params),
   sharedProviderBreakdown: (params) => get('/analytics/shared-provider-breakdown', params),
   gastos: (params) => get('/analytics/gastos', params),
-  syncGastos: () => post('/analytics/gastos/sync'),
+  syncGastos: (params) => post('/analytics/gastos/sync', {}, params),
   cierreSemanal: (params) => get('/analytics/cierre-semanal', params),
   clientProfiles: (params) => get('/analytics/client-profiles', params),
   clvSegments: (params) => get('/analytics/clv-segments', params),

--- a/src/pages/gastos.jsx
+++ b/src/pages/gastos.jsx
@@ -189,7 +189,7 @@ const Gastos = () => {
     setSyncing(true);
     setSyncMsg(null);
     try {
-      const res = await api.syncGastos();
+      const res = await api.syncGastos({ month: `${month}-01` });
       setSyncMsg(
         res.status === 'ok'
           ? `Hoja sincronizada: ${res.egresos_count} egresos y ${res.insumos_count} insumos`


### PR DESCRIPTION
## Summary
- "Actualizar desde la hoja" now sends the currently-selected month (`api.syncGastos({ month })`) instead of always re-syncing today's real-world month regardless of what's on screen. Pairs with zenya-api PR #37 which added the `month` param on the backend.
- `post()` in the API client gained optional query-param support (mirrors `get()`), used here to pass `month`.

## Test plan
- [x] Lint clean, bundle compiles
- [x] User tested locally in browser and confirmed clicking sync while viewing March re-syncs March specifically