### PR TITLE
feat: Rendimiento tab in Personal (margin kept vs. what each employee generated)

### DIFF
--- a/src/components/widgets/staff-rendimiento-panel.jsx
+++ b/src/components/widgets/staff-rendimiento-panel.jsx
@@ -103,7 +103,7 @@ const StaffRendimientoPanel = () => {
         </div>
       ) : (
         <>
-          <div className="z-status-row">
+          <div className="z-kpi-grid">
             <StatCard
               label="Total generado"
               value={money(selected.total_generated)}
@@ -123,10 +123,18 @@ const StaffRendimientoPanel = () => {
             <StatCard
               label="Te queda"
               value={money(selected.total_margin)}
-              caption={`${pct(selected.total_rendimiento_pct)} de lo generado`}
+              caption="generado − pagado"
+              icon="Wallet"
+              numeralStyle="sans"
+              info="Margen sobre lo generado, en pesos: generado − pagado."
+            />
+            <StatCard
+              label="Rendimiento"
+              value={pct(selected.total_rendimiento_pct)}
+              caption="te queda / generado"
               icon="Target"
               numeralStyle="sans"
-              info="Margen sobre lo generado: generado − pagado. El porcentaje en la leyenda es ese margen sobre el total generado por el equipo."
+              info="El margen de arriba, como porcentaje de lo generado por el equipo."
             />
           </div>
 

--- a/src/components/widgets/staff-rendimiento-panel.jsx
+++ b/src/components/widgets/staff-rendimiento-panel.jsx
@@ -1,0 +1,189 @@
+import { useState, useMemo } from 'react';
+import { api } from '../../lib/api';
+import { useApi } from '../../hooks/use-api';
+import Card from '../ui/card';
+import SegmentedControl from '../ui/segmented-control';
+import StatCard from './stat-card';
+import DataTable from './data-table';
+
+const money = (v) => '$' + Math.round(v ?? 0).toLocaleString('es-MX');
+const pct = (v) => (v != null ? Math.round(v * 100) + '%' : '—');
+
+function currentMonthValue() {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+const PERIOD_OPTIONS = [
+  { value: 'sem1', label: 'Sem 1' },
+  { value: 'sem2', label: 'Sem 2' },
+  { value: 'sem3', label: 'Sem 3' },
+  { value: 'sem4', label: 'Sem 4' },
+  { value: 'mes', label: 'Mes completo' },
+];
+
+const RENDIMIENTO_COLS = [
+  { key: 'name', label: 'Empleada' },
+  { key: 'generated', label: 'Generado', align: 'right', sortable: true, sortValue: (r) => r.generated },
+  { key: 'paid', label: 'Pagado', align: 'right', sortable: true, sortValue: (r) => r.paid },
+  {
+    key: 'rendimiento_pct',
+    label: 'Rendimiento',
+    align: 'right',
+    sortable: true,
+    sortValue: (r) => r.rendimiento_pct ?? -1,
+  },
+];
+
+const StaffRendimientoPanel = () => {
+  const [month, setMonth] = useState(currentMonthValue());
+  const [period, setPeriod] = useState('mes');
+
+  const { data, loading } = useApi(() => api.staffRendimiento({ month: `${month}-01` }), [month]);
+
+  const selected = useMemo(() => {
+    if (!data) return null;
+    if (period === 'mes') {
+      return {
+        label: 'Mes completo',
+        entries: data.monthly,
+        total_generated: data.monthly_total_generated,
+        total_paid: data.monthly_total_paid,
+        total_rendimiento_pct: data.monthly_total_rendimiento_pct,
+      };
+    }
+    const idx = Number(period.replace('sem', '')) - 1;
+    const week = data.weeks?.[idx];
+    if (!week) return null;
+    return {
+      label: `${week.semana} (${week.from_date.slice(8)} – ${week.to_date.slice(8)})`,
+      entries: week.entries,
+      total_generated: week.total_generated,
+      total_paid: week.total_paid,
+      total_rendimiento_pct: week.total_rendimiento_pct,
+    };
+  }, [data, period]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <div
+        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 12 }}
+      >
+        <SegmentedControl value={period} onChange={setPeriod} options={PERIOD_OPTIONS} />
+        <input
+          type="month"
+          value={month}
+          onChange={(e) => e.target.value && setMonth(e.target.value)}
+          style={{
+            padding: '6px 10px',
+            borderRadius: 6,
+            border: '1px solid var(--border-subtle)',
+            fontSize: 'var(--text-sm)',
+            fontFamily: 'var(--font-sans)',
+            background: 'var(--surface-card)',
+            color: 'var(--text-body)',
+          }}
+        />
+      </div>
+
+      {loading || !selected ? (
+        <div
+          style={{
+            padding: '30px 0',
+            textAlign: 'center',
+            color: 'var(--text-muted)',
+            fontFamily: 'var(--font-sans)',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          Cargando...
+        </div>
+      ) : (
+        <>
+          <div className="z-status-row">
+            <StatCard
+              label="Total generado"
+              value={money(selected.total_generated)}
+              caption={selected.label}
+              icon="TrendingUp"
+              numeralStyle="sans"
+              info="Ingresos por servicios de todo el personal en el periodo elegido, incluyendo ventas de Lashes/Cosmetología sin nombre identificado en la nota de la cita."
+            />
+            <StatCard
+              label="Total pagado"
+              value={money(selected.total_paid)}
+              caption={selected.label}
+              icon="DollarSign"
+              numeralStyle="sans"
+              info="Suma de los pagos por colaboradora registrados en la hoja de Gastos para el periodo elegido."
+            />
+            <StatCard
+              label="Rendimiento global"
+              value={pct(selected.total_rendimiento_pct)}
+              caption="lo que te queda"
+              icon="Target"
+              numeralStyle="sans"
+              info="Margen sobre lo generado: (generado − pagado) / generado. Es el porcentaje de lo que generó el equipo que te queda a ti."
+            />
+          </div>
+
+          <Card
+            eyebrow="Rendimiento"
+            title={`Por empleada — ${selected.label}`}
+            info="Rendimiento = (generado − pagado) / generado — el margen que te queda de lo que generó cada empleada. '—' significa que no generó ventas propias en este periodo (ej. recepción), pero su pago sigue contando en el total del equipo."
+          >
+            {selected.entries.length > 0 ? (
+              <DataTable
+                columns={RENDIMIENTO_COLS}
+                rows={selected.entries}
+                renderCell={(row, key) => {
+                  if (key === 'name')
+                    return <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.name}</span>;
+                  if (key === 'generated') return money(row.generated);
+                  if (key === 'paid') return money(row.paid);
+                  if (key === 'rendimiento_pct')
+                    return row.rendimiento_pct != null ? (
+                      <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{pct(row.rendimiento_pct)}</span>
+                    ) : (
+                      <span style={{ color: 'var(--text-muted)' }}>—</span>
+                    );
+                  return row[key] ?? '—';
+                }}
+              />
+            ) : (
+              <div
+                style={{
+                  padding: '20px 0',
+                  textAlign: 'center',
+                  color: 'var(--text-muted)',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                }}
+              >
+                Sin datos para este periodo
+              </div>
+            )}
+
+            {data.unassigned_generated > 0 && (
+              <div
+                style={{
+                  marginTop: 14,
+                  paddingTop: 14,
+                  borderTop: '1px solid var(--border-subtle)',
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--text-muted)',
+                }}
+              >
+                Incluye {money(data.unassigned_generated)} de ventas en Lashes/Cosmetología del mes sin un nombre
+                identificado en la nota de la cita — cuentan en el total del equipo pero no en ninguna fila individual.
+              </div>
+            )}
+          </Card>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default StaffRendimientoPanel;

--- a/src/components/widgets/staff-rendimiento-panel.jsx
+++ b/src/components/widgets/staff-rendimiento-panel.jsx
@@ -26,6 +26,7 @@ const RENDIMIENTO_COLS = [
   { key: 'name', label: 'Empleada' },
   { key: 'generated', label: 'Generado', align: 'right', sortable: true, sortValue: (r) => r.generated },
   { key: 'paid', label: 'Pagado', align: 'right', sortable: true, sortValue: (r) => r.paid },
+  { key: 'margin', label: 'Te queda', align: 'right', sortable: true, sortValue: (r) => r.margin },
   {
     key: 'rendimiento_pct',
     label: 'Rendimiento',
@@ -49,6 +50,7 @@ const StaffRendimientoPanel = () => {
         entries: data.monthly,
         total_generated: data.monthly_total_generated,
         total_paid: data.monthly_total_paid,
+        total_margin: data.monthly_total_margin,
         total_rendimiento_pct: data.monthly_total_rendimiento_pct,
       };
     }
@@ -60,6 +62,7 @@ const StaffRendimientoPanel = () => {
       entries: week.entries,
       total_generated: week.total_generated,
       total_paid: week.total_paid,
+      total_margin: week.total_margin,
       total_rendimiento_pct: week.total_rendimiento_pct,
     };
   }, [data, period]);
@@ -118,12 +121,12 @@ const StaffRendimientoPanel = () => {
               info="Suma de los pagos por colaboradora registrados en la hoja de Gastos para el periodo elegido."
             />
             <StatCard
-              label="Rendimiento global"
-              value={pct(selected.total_rendimiento_pct)}
-              caption="lo que te queda"
+              label="Te queda"
+              value={money(selected.total_margin)}
+              caption={`${pct(selected.total_rendimiento_pct)} de lo generado`}
               icon="Target"
               numeralStyle="sans"
-              info="Margen sobre lo generado: (generado − pagado) / generado. Es el porcentaje de lo que generó el equipo que te queda a ti."
+              info="Margen sobre lo generado: generado − pagado. El porcentaje en la leyenda es ese margen sobre el total generado por el equipo."
             />
           </div>
 
@@ -141,6 +144,14 @@ const StaffRendimientoPanel = () => {
                     return <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.name}</span>;
                   if (key === 'generated') return money(row.generated);
                   if (key === 'paid') return money(row.paid);
+                  if (key === 'margin')
+                    return (
+                      <span
+                        style={{ fontWeight: 600, color: row.margin < 0 ? 'var(--negative)' : 'var(--text-display)' }}
+                      >
+                        {money(row.margin)}
+                      </span>
+                    );
                   if (key === 'rendimiento_pct')
                     return row.rendimiento_pct != null ? (
                       <span style={{ fontWeight: 600, color: 'var(--text-display)' }}>{pct(row.rendimiento_pct)}</span>

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -40,6 +40,7 @@ export const api = {
   revenueByDay: (params) => get('/analytics/revenue-by-day', params),
   topServices: (params) => get('/analytics/top-services', params),
   staffPerformance: (params) => get('/analytics/staff-performance', params),
+  staffRendimiento: (params) => get('/analytics/staff-rendimiento', params),
   paymentMethodsBreakdown: (params) => get('/analytics/payment-methods-breakdown', params),
   clientRetention: (params) => get('/analytics/client-retention', params),
   clientStats: (params) => get('/analytics/client-stats', params),

--- a/src/pages/staff.jsx
+++ b/src/pages/staff.jsx
@@ -11,6 +11,7 @@ import DataTable from '../components/widgets/data-table';
 import Avatar from '../components/ui/avatar';
 import SegmentedControl from '../components/ui/segmented-control';
 import StaffHoursPanel from '../components/widgets/staff-hours-panel';
+import StaffRendimientoPanel from '../components/widgets/staff-rendimiento-panel';
 
 const money = (v) => '$' + Math.round(v).toLocaleString('es-MX');
 const CHART = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
@@ -71,11 +72,14 @@ const Staff = ({ dateRange }) => {
         onChange={setTab}
         options={[
           { value: 'performance', label: 'Desempeño' },
+          { value: 'rendimiento', label: 'Rendimiento' },
           { value: 'hours', label: 'Horas' },
         ]}
       />
 
       {tab === 'hours' && <StaffHoursPanel />}
+
+      {tab === 'rendimiento' && <StaffRendimientoPanel />}
 
       {tab === 'performance' && (
         <>


### PR DESCRIPTION
## Summary
- New "Rendimiento" tab in Personal alongside Desempeño/Horas: per-employee generated revenue vs. amount paid, with a Sem 1-4 / Mes completo period selector and its own month picker.
- Shows both the peso amount kept ("Te queda") and the percentage ("Rendimiento") as separate KPI cards, plus per-employee columns for both.
- Pairs with zenya-api PR #38 (already merged/deployed to stage).

## Test plan
- [x] Lint clean
- [x] User tested locally in browser (via an isolated worktree, port 3001) and confirmed the numbers and both amount+percentage display