### PR TITLE
fix: prettier formatting that broke the stage build

### DIFF
--- a/src/components/widgets/client-detail-modal.jsx
+++ b/src/components/widgets/client-detail-modal.jsx
@@ -281,7 +281,12 @@ const ClientDetailModal = ({ clientId, onClose }) => {
                 }}
               >
                 <MiniStat icon={Repeat} label="Visitas" value={stats.total_visits} caption="compras completadas" />
-                <MiniStat icon={DollarSign} label="Ingresos" value={money(stats.lifetime_revenue)} caption="histórico" />
+                <MiniStat
+                  icon={DollarSign}
+                  label="Ingresos"
+                  value={money(stats.lifetime_revenue)}
+                  caption="histórico"
+                />
                 <MiniStat icon={DollarSign} label="Ticket prom." value={money(stats.avg_ticket)} />
                 <MiniStat
                   icon={Clock}

--- a/src/pages/clients.jsx
+++ b/src/pages/clients.jsx
@@ -749,9 +749,7 @@ const Clients = ({ dateRange }) => {
       )}
 
       {/* ── REACTIVACIÓN TAB ── */}
-      {tab === 'reactivacion' && (
-        <ReactivationPanel profiles={profilesData} onSelectClient={setSelectedClientId} />
-      )}
+      {tab === 'reactivacion' && <ReactivationPanel profiles={profilesData} onSelectClient={setSelectedClientId} />}
 
       {/* ── CLV & SEGMENTOS TAB ── */}
       {tab === 'clv' && (


### PR DESCRIPTION
## Summary
- The client-detail-modal PR (#65) left two prettier formatting nits that are non-fatal locally but fail CI's `npm run build` (CI=true treats eslint warnings as errors) — this broke the stage deploy.
- Pure formatting fix, no logic change.

## Test plan
- [x] `CI=true npm run build` compiles clean locally.