### PR TITLE
fix: staff-rendimiento total_generated now matches Resumen + row-level unassigned tracking

### DIFF
--- a/src/components/widgets/staff-rendimiento-panel.jsx
+++ b/src/components/widgets/staff-rendimiento-panel.jsx
@@ -178,15 +178,26 @@ const StaffRendimientoPanel = () => {
           <Card
             eyebrow="Rendimiento"
             title={`Por empleada — ${selected.label}`}
-            info="Rendimiento = (generado − pagado) / generado — el margen que te queda de lo que generó cada empleada. '—' significa que no generó ventas propias en este periodo (ej. recepción), pero su pago sigue contando en el total del equipo."
+            info="Rendimiento = (generado − pagado) / generado — el margen que te queda de lo que generó cada empleada. '—' significa que no generó ventas propias en este periodo (ej. recepción), pero su pago sigue contando en el total del equipo. La fila 'No asignado' son servicios sin ninguna colaboradora asignada en AgendaPro (mismos que 'Servicios no asignados' en Desempeño) — no pagan comisión, así que es 100% ganancia."
           >
             {selected.entries.length > 0 ? (
               <DataTable
                 columns={RENDIMIENTO_COLS}
                 rows={selected.entries}
                 renderCell={(row, key) => {
+                  const isUnassigned = row.name === 'No asignado';
                   if (key === 'name')
-                    return <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.name}</span>;
+                    return (
+                      <span
+                        style={{
+                          fontWeight: isUnassigned ? 500 : 600,
+                          fontStyle: isUnassigned ? 'italic' : 'normal',
+                          color: isUnassigned ? 'var(--text-muted)' : 'var(--text-heading)',
+                        }}
+                      >
+                        {row.name}
+                      </span>
+                    );
                   if (key === 'generated') return money(row.generated);
                   if (key === 'paid') return money(row.paid);
                   if (key === 'margin')
@@ -222,13 +233,8 @@ const StaffRendimientoPanel = () => {
 
             <PureProfitCallout
               title={`No asignados en Lashes/Cosmetología — ${selected.label}`}
-              note="Ventas sin un nombre identificado en la nota de la cita: no se les paga comisión, así que es ganancia pura para ti."
+              note="Ventas sin un nombre identificado en la nota de la cita: no se les paga comisión, así que es ganancia pura para ti. Estas no aparecen como fila propia porque no se puede saber si son de Lashes o Cosmetología."
               amount={selected.unassigned_generated}
-            />
-            <PureProfitCallout
-              title={`Servicios sin colaboradora asignada — ${selected.label}`}
-              note="Ventas sin ningún profesional asignado en AgendaPro (diseños, cejas, extras de walk-in): tampoco se les paga comisión."
-              amount={selected.unassigned_provider_generated}
             />
           </Card>
         </>

--- a/src/components/widgets/staff-rendimiento-panel.jsx
+++ b/src/components/widgets/staff-rendimiento-panel.jsx
@@ -52,6 +52,7 @@ const StaffRendimientoPanel = () => {
         total_paid: data.monthly_total_paid,
         total_margin: data.monthly_total_margin,
         total_rendimiento_pct: data.monthly_total_rendimiento_pct,
+        unassigned_generated: data.unassigned_generated,
       };
     }
     const idx = Number(period.replace('sem', '')) - 1;
@@ -64,6 +65,7 @@ const StaffRendimientoPanel = () => {
       total_paid: week.total_paid,
       total_margin: week.total_margin,
       total_rendimiento_pct: week.total_rendimiento_pct,
+      unassigned_generated: week.unassigned_generated,
     };
   }, [data, period]);
 
@@ -183,19 +185,38 @@ const StaffRendimientoPanel = () => {
               </div>
             )}
 
-            {data.unassigned_generated > 0 && (
+            {selected.unassigned_generated > 0 && (
               <div
                 style={{
                   marginTop: 14,
-                  paddingTop: 14,
-                  borderTop: '1px solid var(--border-subtle)',
-                  fontFamily: 'var(--font-sans)',
-                  fontSize: 'var(--text-xs)',
-                  color: 'var(--text-muted)',
+                  padding: '12px 14px',
+                  borderRadius: 'var(--radius-sm)',
+                  background: 'var(--positive-soft)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                  flexWrap: 'wrap',
                 }}
               >
-                Incluye {money(data.unassigned_generated)} de ventas en Lashes/Cosmetología del mes sin un nombre
-                identificado en la nota de la cita — cuentan en el total del equipo pero no en ninguna fila individual.
+                <span style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}>
+                  No asignados en Lashes/Cosmetología — {selected.label}
+                  <br />
+                  <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                    Ventas sin un nombre identificado en la nota de la cita: no se les paga comisión, así que es
+                    ganancia pura para ti.
+                  </span>
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-sans)',
+                    fontSize: 'var(--text-xl)',
+                    fontWeight: 700,
+                    color: 'var(--positive)',
+                  }}
+                >
+                  {money(selected.unassigned_generated)}
+                </span>
               </div>
             )}
           </Card>

--- a/src/components/widgets/staff-rendimiento-panel.jsx
+++ b/src/components/widgets/staff-rendimiento-panel.jsx
@@ -36,6 +36,39 @@ const RENDIMIENTO_COLS = [
   },
 ];
 
+const PureProfitCallout = ({ title, note, amount }) =>
+  amount > 0 && (
+    <div
+      style={{
+        marginTop: 10,
+        padding: '12px 14px',
+        borderRadius: 'var(--radius-sm)',
+        background: 'var(--positive-soft)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+        flexWrap: 'wrap',
+      }}
+    >
+      <span style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}>
+        {title}
+        <br />
+        <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{note}</span>
+      </span>
+      <span
+        style={{
+          fontFamily: 'var(--font-sans)',
+          fontSize: 'var(--text-xl)',
+          fontWeight: 700,
+          color: 'var(--positive)',
+        }}
+      >
+        {money(amount)}
+      </span>
+    </div>
+  );
+
 const StaffRendimientoPanel = () => {
   const [month, setMonth] = useState(currentMonthValue());
   const [period, setPeriod] = useState('mes');
@@ -53,6 +86,7 @@ const StaffRendimientoPanel = () => {
         total_margin: data.monthly_total_margin,
         total_rendimiento_pct: data.monthly_total_rendimiento_pct,
         unassigned_generated: data.unassigned_generated,
+        unassigned_provider_generated: data.unassigned_provider_generated,
       };
     }
     const idx = Number(period.replace('sem', '')) - 1;
@@ -66,6 +100,7 @@ const StaffRendimientoPanel = () => {
       total_margin: week.total_margin,
       total_rendimiento_pct: week.total_rendimiento_pct,
       unassigned_generated: week.unassigned_generated,
+      unassigned_provider_generated: week.unassigned_provider_generated,
     };
   }, [data, period]);
 
@@ -112,7 +147,7 @@ const StaffRendimientoPanel = () => {
               caption={selected.label}
               icon="TrendingUp"
               numeralStyle="sans"
-              info="Ingresos por servicios de todo el personal en el periodo elegido, incluyendo ventas de Lashes/Cosmetología sin nombre identificado en la nota de la cita."
+              info="Ingresos por servicios de todo el personal en el periodo elegido, incluyendo ventas sin nombre identificado en Lashes/Cosmetología y servicios sin ninguna colaboradora asignada en AgendaPro."
             />
             <StatCard
               label="Total pagado"
@@ -185,40 +220,16 @@ const StaffRendimientoPanel = () => {
               </div>
             )}
 
-            {selected.unassigned_generated > 0 && (
-              <div
-                style={{
-                  marginTop: 14,
-                  padding: '12px 14px',
-                  borderRadius: 'var(--radius-sm)',
-                  background: 'var(--positive-soft)',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  gap: 12,
-                  flexWrap: 'wrap',
-                }}
-              >
-                <span style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}>
-                  No asignados en Lashes/Cosmetología — {selected.label}
-                  <br />
-                  <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-                    Ventas sin un nombre identificado en la nota de la cita: no se les paga comisión, así que es
-                    ganancia pura para ti.
-                  </span>
-                </span>
-                <span
-                  style={{
-                    fontFamily: 'var(--font-sans)',
-                    fontSize: 'var(--text-xl)',
-                    fontWeight: 700,
-                    color: 'var(--positive)',
-                  }}
-                >
-                  {money(selected.unassigned_generated)}
-                </span>
-              </div>
-            )}
+            <PureProfitCallout
+              title={`No asignados en Lashes/Cosmetología — ${selected.label}`}
+              note="Ventas sin un nombre identificado en la nota de la cita: no se les paga comisión, así que es ganancia pura para ti."
+              amount={selected.unassigned_generated}
+            />
+            <PureProfitCallout
+              title={`Servicios sin colaboradora asignada — ${selected.label}`}
+              note="Ventas sin ningún profesional asignado en AgendaPro (diseños, cejas, extras de walk-in): tampoco se les paga comisión."
+              amount={selected.unassigned_provider_generated}
+            />
           </Card>
         </>
       )}

--- a/src/components/widgets/staff-rendimiento-panel.jsx
+++ b/src/components/widgets/staff-rendimiento-panel.jsx
@@ -86,7 +86,6 @@ const StaffRendimientoPanel = () => {
         total_margin: data.monthly_total_margin,
         total_rendimiento_pct: data.monthly_total_rendimiento_pct,
         unassigned_generated: data.unassigned_generated,
-        unassigned_provider_generated: data.unassigned_provider_generated,
       };
     }
     const idx = Number(period.replace('sem', '')) - 1;
@@ -100,7 +99,6 @@ const StaffRendimientoPanel = () => {
       total_margin: week.total_margin,
       total_rendimiento_pct: week.total_rendimiento_pct,
       unassigned_generated: week.unassigned_generated,
-      unassigned_provider_generated: week.unassigned_provider_generated,
     };
   }, [data, period]);
 
@@ -147,7 +145,7 @@ const StaffRendimientoPanel = () => {
               caption={selected.label}
               icon="TrendingUp"
               numeralStyle="sans"
-              info="Ingresos por servicios de todo el personal en el periodo elegido, incluyendo ventas sin nombre identificado en Lashes/Cosmetología y servicios sin ninguna colaboradora asignada en AgendaPro."
+              info="Ingresos de servicios y productos de todo el personal en el periodo elegido, incluyendo ventas sin nombre identificado en Lashes/Cosmetología y servicios o productos sin ninguna colaboradora asignada en AgendaPro."
             />
             <StatCard
               label="Total pagado"
@@ -178,14 +176,14 @@ const StaffRendimientoPanel = () => {
           <Card
             eyebrow="Rendimiento"
             title={`Por empleada — ${selected.label}`}
-            info="Rendimiento = (generado − pagado) / generado — el margen que te queda de lo que generó cada empleada. '—' significa que no generó ventas propias en este periodo (ej. recepción), pero su pago sigue contando en el total del equipo. La fila 'No asignado' son servicios sin ninguna colaboradora asignada en AgendaPro (mismos que 'Servicios no asignados' en Desempeño) — no pagan comisión, así que es 100% ganancia."
+            info="Rendimiento = (generado − pagado) / generado — el margen que te queda de lo que generó cada empleada. '—' significa que no generó ventas propias en este periodo (ej. recepción), pero su pago sigue contando en el total del equipo. 'No asignado' y 'Productos no asignados' son servicios y productos sin ninguna colaboradora asignada en AgendaPro (los servicios son los mismos que 'Servicios no asignados' en Desempeño) — no pagan comisión, así que son 100% ganancia."
           >
             {selected.entries.length > 0 ? (
               <DataTable
                 columns={RENDIMIENTO_COLS}
                 rows={selected.entries}
                 renderCell={(row, key) => {
-                  const isUnassigned = row.name === 'No asignado';
+                  const isUnassigned = row.name === 'No asignado' || row.name === 'Productos no asignados';
                   if (key === 'name')
                     return (
                       <span


### PR DESCRIPTION
## Summary
Recovers previously-built-but-never-shipped work plus today's fixes, pairing with zenya-api PR #44:

- Renders the new trailing "No asignado" (services) and "Productos no asignados" (products) rows in the per-employee table, styled distinctly (muted italic) since neither is a real staff member.
- Removed the now-redundant "Servicios sin colaboradora asignada" callout since the table row covers it; kept the Lashes/Cosmetología callout since that pool still can't be broken out per-row.
- Total generado now matches the Resumen page exactly (products included).

## Test plan
- [x] Lint clean, bundle compiles
- [x] User tested locally in browser and confirmed it works