### PR TITLE
fix: drop 'Contactada · ' prefix from Campaña badge to save space

### DIFF
--- a/src/components/widgets/reactivation-panel.jsx
+++ b/src/components/widgets/reactivation-panel.jsx
@@ -88,7 +88,7 @@ function campaignCell(send) {
   return (
     <span title={`Enviado el ${fmtDate(send.sent_at)}`}>
       <Badge tone="lavender" size="sm" dot>
-        Contactada · {templateLabel}
+        {templateLabel}
       </Badge>
     </span>
   );


### PR DESCRIPTION
## Summary
- Badge in Reactivación's Campaña column now shows just the template name for a contacted-not-yet-reactivated client, instead of "Contactada · {plantilla}" — less clutter now that the table has more columns. "Sin contactar" and "Reactivada · {plantilla}" unchanged.

## Test plan
- [x] Lint clean, bundle compiles
- [x] User tested locally in browser and confirmed it works