### PR TITLE
fix: exclude clients with an upcoming booking from Reactivación

### DIFF
--- a/src/components/widgets/reactivation-panel.jsx
+++ b/src/components/widgets/reactivation-panel.jsx
@@ -183,6 +183,12 @@ const CANDIDATE_COLS = [
     sortValue: (r) => r.days_since_last,
   },
   { key: 'estado', label: 'Estado', sortable: true, sortValue: (r) => ESTADO_RANK[r.churn_status] ?? 3 },
+  {
+    key: 'proxima_cita',
+    label: 'Próxima cita',
+    sortable: true,
+    sortValue: (r) => r.next_booking_date ?? '',
+  },
   { key: 'campana', label: 'Campaña', sortable: true, sortValue: (r) => campaignRank(r.latestSend) },
   {
     key: 'enviado',
@@ -227,7 +233,13 @@ const ReactivationPanel = ({ profiles, onSelectClient }) => {
     const profileByClient = new Map((profiles ?? []).map((p) => [p.client_id, p]));
     const ids = new Set();
     (profiles ?? []).forEach((p) => {
-      if (p.churn_status === 'at_risk' || p.churn_status === 'churned') ids.add(p.client_id);
+      // A client already has something booked doesn't need a nudge to come
+      // back — this is the exact check that was missing when a reminder
+      // went out to a client who'd already rebooked (see backend
+      // has_upcoming_booking / REACTIVATION_UPCOMING_BOOKING_DAYS).
+      if ((p.churn_status === 'at_risk' || p.churn_status === 'churned') && !p.has_upcoming_booking) {
+        ids.add(p.client_id);
+      }
     });
     // Keep clients we've contacted before even after they come back — we still want to see the win.
     latestSendByClient.forEach((_send, clientId) => ids.add(clientId));
@@ -243,6 +255,7 @@ const ReactivationPanel = ({ profiles, onSelectClient }) => {
           phone: profile?.phone ?? send?.phone,
           days_since_last: profile?.days_since_last ?? null,
           churn_status: profile?.churn_status ?? null,
+          next_booking_date: profile?.next_booking_date ?? null,
           latestSend: send,
         };
       })
@@ -275,7 +288,14 @@ const ReactivationPanel = ({ profiles, onSelectClient }) => {
     if (!template || !client.phone) return;
     const message = fillTemplate(template.body, client.first_name);
     window.open(buildWhatsappUrl(client.phone, message), '_blank', 'noopener');
-    await api.createWhatsappSend({ client_id: client.client_id, template_id: template.id });
+    try {
+      await api.createWhatsappSend({ client_id: client.client_id, template_id: template.id });
+    } catch (err) {
+      // The WhatsApp Web tab is already open at this point (can't undo
+      // that) — this just means the send wasn't logged, most likely
+      // because she rebooked between when this list loaded and now.
+      alert(err.message || 'No se pudo registrar el envío.');
+    }
     setRefreshKey((k) => k + 1);
   };
 
@@ -484,6 +504,14 @@ const ReactivationPanel = ({ profiles, onSelectClient }) => {
                     <span style={{ color: 'var(--text-muted)' }}>—</span>
                   );
                 if (key === 'estado') return estadoBadge(row.churn_status);
+                if (key === 'proxima_cita')
+                  return row.next_booking_date ? (
+                    <Badge tone="caution" size="sm">
+                      {fmtDate(row.next_booking_date)}
+                    </Badge>
+                  ) : (
+                    <span style={{ color: 'var(--text-muted)' }}>—</span>
+                  );
                 if (key === 'campana') return campaignCell(row.latestSend);
                 if (key === 'enviado')
                   return row.latestSend?.sent_at ? (

--- a/src/components/widgets/reminder-campaign-panel.jsx
+++ b/src/components/widgets/reminder-campaign-panel.jsx
@@ -182,7 +182,15 @@ const ReminderCampaignPanel = ({
     if (!template || !client.phone) return;
     const message = fillTemplate(template.body, client.first_name);
     window.open(buildWhatsappUrl(client.phone, message), '_blank', 'noopener');
-    await api.createWhatsappSend({ client_id: client.client_id, template_id: template.id });
+    try {
+      await api.createWhatsappSend({ client_id: client.client_id, template_id: template.id });
+    } catch (err) {
+      // The WhatsApp Web tab is already open at this point (can't undo
+      // that) — this just means the send wasn't logged, most likely
+      // because she rebooked between when this list loaded and now.
+      alert(err.message || 'No se pudo registrar el envío.');
+      return;
+    }
     setClients((prev) =>
       prev.map((c) =>
         c.client_id === client.client_id ? { ...c, reminder_sent: true, reminder_sent_at: new Date().toISOString() } : c

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -17,7 +17,17 @@ async function post(path, body, params) {
     headers: { 'X-API-Key': API_KEY, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error(`API ${res.status}: ${path}`);
+  if (!res.ok) {
+    // FastAPI's HTTPException detail (e.g. "ya tiene una cita agendada...")
+    // is much more useful to a caller than a bare status code — surface it
+    // when present instead of always throwing the generic message.
+    const detail = await res
+      .clone()
+      .json()
+      .then((d) => d.detail)
+      .catch(() => null);
+    throw new Error(detail || `API ${res.status}: ${path}`);
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
Frontend half of the fix for the critical incident (client got a retouch reminder despite already having a booking).

- Reactivación candidate list now excludes clients with `has_upcoming_booking=true` (30-day forward check from the backend) — previously the only signal was `churn_status`, with zero booking-awareness.
- New "Próxima cita" column as a visual safety net.
- Both reactivation-panel and reminder-campaign-panel (retouch) now surface the server's error message if a send gets rejected (server can now reject with 409 if the client rebooked between page load and click) instead of failing silently.
- `api.js`'s `post()` helper now surfaces the backend's actual error detail instead of a generic "API 409: ..." message.
- Depends on zenya-api#51 and zenya-ingestor#22/#23 (all already merged and deployed).

## Test plan
- Verified locally end-to-end against the deployed backend using the real client from the incident — no longer appears as a reactivation/retouch candidate, and a manual send attempt is blocked with a clear error message.
- User confirmed working locally.