### PR TITLE
fix: total de ingresos del día en Citas usa ventas reales, no el precio agendado

### DIFF
--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -172,6 +172,12 @@ const Appointments = () => {
     [selectedDate]
   );
   const { data: profList } = useApi(() => api.professionals(), []);
+  // Real revenue for the day comes from actual sales (accounts for discounts /
+  // services added at checkout), not from the amount each booking was scheduled at.
+  const { data: revenueDay, loading: revenueLoading } = useApi(
+    () => api.revenueByDay({ from_date: selectedDate, to_date: selectedDate }),
+    [selectedDate]
+  );
 
   const profNames = useMemo(() => {
     const map = {};
@@ -195,7 +201,7 @@ const Appointments = () => {
   const paid = rows.filter((r) => r.payment_status === 'ASSOCIATED' || r.status === 'paid').length;
   const unpaid = rows.filter((r) => !r.payment_status || r.payment_status === 'UNPAID').length;
   const pending = rows.length - paid - unpaid;
-  const totalRev = rows.reduce((s, r) => s + (r.amount ?? 0), 0);
+  const totalRev = (revenueDay ?? []).reduce((s, d) => s + (d.revenue ?? 0), 0);
   const paymentCounts = { paid, pending: Math.max(0, pending), unpaid };
 
   const displayDate = parseLocalDate(selectedDate).toLocaleDateString('es-MX', {
@@ -274,7 +280,7 @@ const Appointments = () => {
         />
         <StatCard
           label="Ingresos del día"
-          value={loading ? '…' : money(totalRev)}
+          value={revenueLoading ? '…' : money(totalRev)}
           caption="citas con pago"
           icon="DollarSign"
         />


### PR DESCRIPTION
## Qué cambia

`Ingresos del día` en la página de Citas sumaba `booking.amount` (el precio con el que se agendó cada cita), lo cual no refleja descuentos ni servicios agregados al vuelo en caja. El total del día quedaba mal cuadrado frente a lo realmente cobrado.

Ahora se usa el endpoint ya existente `/analytics/revenue-by-day` (suma `Sale.total_amount` real por día) para ese total, en vez de recalcularlo sumando las citas agendadas.

## Verificación local

Con datos reales del 4 de agosto:
- Suma de citas agendadas (comportamiento anterior): $2,682
- Ingresos reales de ventas ese día (comportamiento nuevo): $2,913

Probado en `localhost:3011` contra la API local, confirmado visualmente por el usuario.

## Fuera de alcance

El total individual de cada fila de cita sigue mostrando el precio agendado (no el cobrado real por esa cita puntual) — cambiarlo requeriría cruzar cada cita con las líneas de venta, que es un cambio más grande no solicitado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)