### PR TITLE
Estandarizar formato de fecha a DD/MM/YYYY

### DIFF
--- a/src/components/ui/date-range-picker.jsx
+++ b/src/components/ui/date-range-picker.jsx
@@ -1,12 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 import { CalendarDays, ChevronDown } from 'lucide-react';
 
-const MONTHS_SHORT = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
-
 function fmtDate(iso) {
   if (!iso) return '';
-  const [, m, d] = iso.split('-');
-  return `${parseInt(d)} ${MONTHS_SHORT[parseInt(m) - 1]}`;
+  const [y, m, d] = iso.split('-');
+  return `${d}/${m}/${y}`;
 }
 
 function todayIso() {

--- a/src/components/widgets/appointment-reminders.jsx
+++ b/src/components/widgets/appointment-reminders.jsx
@@ -31,29 +31,14 @@ Agradeceríamos mucho si nos ayudas confirmando este mensaje para tener todo lis
 
 Zenya Nails & Spa 🌸`;
 
-const MONTHS_ES = [
-  'enero',
-  'febrero',
-  'marzo',
-  'abril',
-  'mayo',
-  'junio',
-  'julio',
-  'agosto',
-  'septiembre',
-  'octubre',
-  'noviembre',
-  'diciembre',
-];
-
-function formatFechaManana(targetDateStr) {
-  const [, m, d] = (targetDateStr || '').split('-').map(Number);
-  if (!m || !d) return 'mañana';
-  return `mañana ${d} de ${MONTHS_ES[m - 1]}`;
+function formatFecha(targetDateStr) {
+  if (!targetDateStr) return '';
+  const [y, m, d] = targetDateStr.split('-');
+  return `${d}/${m}/${y}`;
 }
 
 function buildDetalleCita(appointments, targetDate) {
-  const lines = [`📅 Fecha: ${formatFechaManana(targetDate)}`];
+  const lines = [`📅 Fecha: ${formatFecha(targetDate)}`];
   (appointments ?? []).forEach((a) => {
     lines.push(`⏰ Hora: ${a.time}`);
     lines.push(`💗 Servicio: ${a.service_name ?? 'Servicio'}`);

--- a/src/components/widgets/client-detail-modal.jsx
+++ b/src/components/widgets/client-detail-modal.jsx
@@ -11,7 +11,7 @@ const money = (v) => '$' + Math.round(v ?? 0).toLocaleString('es-MX');
 
 function fmtDate(iso) {
   if (!iso) return '—';
-  return new Date(iso).toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
+  return new Date(iso).toLocaleDateString('es-MX', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
 function fmtTime(iso) {

--- a/src/components/widgets/staff-hours-panel.jsx
+++ b/src/components/widgets/staff-hours-panel.jsx
@@ -8,8 +8,6 @@ import IconButton from '../ui/icon-button';
 import Select from '../ui/select';
 import DataTable from './data-table';
 
-const MONTHS_SHORT = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
-
 // The only individually-tracked manicuristas — "Cosmetología" and "Lashes y
 // cejas" are shared AgendaPro accounts for a service, not people who can owe
 // or be owed time, so they're excluded from this ledger.
@@ -17,8 +15,8 @@ const TRACKED_PROFESSIONAL_NAMES = ['Danna Aquino', 'Guadalupe Villegas Martíne
 
 function fmtDate(iso) {
   if (!iso) return '—';
-  const [y, m, d] = iso.split('-').map(Number);
-  return `${d} ${MONTHS_SHORT[m - 1]} ${y}`;
+  const [y, m, d] = iso.split('-');
+  return `${d}/${m}/${y}`;
 }
 
 function fmtDuration(minutes) {

--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -199,9 +199,9 @@ const Appointments = () => {
   const paymentCounts = { paid, pending: Math.max(0, pending), unpaid };
 
   const displayDate = parseLocalDate(selectedDate).toLocaleDateString('es-MX', {
-    weekday: 'long',
-    day: 'numeric',
-    month: 'long',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
   });
 
   const calEyebrow =


### PR DESCRIPTION
## Resumen
Convierte todas las fechas visibles en la app al formato mexicano numérico DD/MM/YYYY:

- Detalle de clienta (última visita, historial de citas): `05 ago 2026` → `05/08/2026`
- Personal → Horas (registro de horas y vacaciones): `5 ago 2026` → `5/08/2026`
- Selector de rango de fechas (Overview/Revenue/etc.): `5 ago – 12 ago` → `05/08/2026 – 12/08/2026`
- Citas (encabezado "Citas — ..."): `lunes, 15 de agosto` → `15/08/2026`
- Mensaje de WhatsApp de recordatorio: `📅 Fecha: mañana 15 de agosto` → `📅 Fecha: 15/08/2026`

Fuera de alcance a propósito: mini-calendario de Citas, eyebrow del widget Calendario y eje mensual de la gráfica en Overview — son encabezados de navegación de calendario/gráfica donde el nombre del mes es la convención estándar, no una fecha puntual.

## Test plan
- [x] `npm run lint` limpio
- [x] Probado en localhost:3010 contra API local — confirmado visualmente por el usuario

🤖 Generated with [Claude Code](https://claude.com/claude-code)