### PR TITLE
fix: show real checkout total per cita

### DIFF
--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -308,7 +308,7 @@ const Appointments = () => {
               renderCell={(row, key) => {
                 if (key === 'service') return row.service_name ?? '—';
                 if (key === 'status') return <ApptStatus status={row.status} />;
-                if (key === 'total') return money(row.amount ?? 0);
+                if (key === 'total') return money(row.sale_total_amount ?? row.amount ?? 0);
                 return row[key];
               }}
             />


### PR DESCRIPTION
## Summary
- The "Total" column on the Citas page showed `booking.amount` only — the booked service's own price — never accounting for items added at checkout beyond the appointment.
- Now uses the new `sale_total_amount` field from `/bookings` (zenya-api PR #53) when available, falling back to `amount` for bookings not yet linked to a sale.

## Test plan
- [x] Verified locally at localhost:3011 against the fixed API — Dec 30 2025 now shows $2,480 instead of $500/$180 split across two rows for the same cart.
- [x] `npx eslint src/pages/appointments.jsx` clean.