### PR TITLE
feat: click en nombre de clienta abre historial en paneles de recordatorio

### DIFF
--- a/src/components/widgets/reminder-campaign-panel.jsx
+++ b/src/components/widgets/reminder-campaign-panel.jsx
@@ -63,6 +63,7 @@ const ReminderCampaignPanel = ({
   emptyBeforeSyncText,
   emptyAfterSyncText,
   dismissable = false,
+  onSelectClient,
 }) => {
   const [template, setTemplate] = useState(null);
   const [templateLoaded, setTemplateLoaded] = useState(false);
@@ -328,7 +329,18 @@ const ReminderCampaignPanel = ({
                 return (
                   <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                     <Avatar name={row.name} size="sm" tone="ink" />
-                    <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.name}</span>
+                    {onSelectClient ? (
+                      <button
+                        type="button"
+                        className="z-client-name"
+                        title="Ver historial de la clienta"
+                        onClick={() => onSelectClient(row.client_id)}
+                      >
+                        {row.name}
+                      </button>
+                    ) : (
+                      <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{row.name}</span>
+                    )}
                   </div>
                 );
               if (key === 'phone') return <span style={{ color: 'var(--text-secondary)' }}>{row.phone ?? '—'}</span>;

--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -8,6 +8,7 @@ import ApptStatus from '../components/widgets/appt-status';
 import AppointmentReminders from '../components/widgets/appointment-reminders';
 import ReminderCampaignPanel from '../components/widgets/reminder-campaign-panel';
 import ReminderEffectivenessCard from '../components/widgets/reminder-effectiveness-card';
+import ClientDetailModal from '../components/widgets/client-detail-modal';
 import Badge from '../components/ui/badge';
 import { ChevronLeft, ChevronRight, CheckCircle, Clock, XCircle } from 'lucide-react';
 
@@ -167,6 +168,7 @@ const MiniCalendar = ({ selectedDate, onSelect }) => {
 
 const Appointments = () => {
   const [selectedDate, setSelectedDate] = useState(localToday);
+  const [selectedClientId, setSelectedClientId] = useState(null);
   const { data: bookings, loading } = useApi(
     () => api.bookings({ from_date: selectedDate, to_date: selectedDate, limit: 200 }),
     [selectedDate]
@@ -387,6 +389,7 @@ Será un placer atenderte 💕 Bonito día! ☺️`}
         emptyBeforeSyncText='Da clic en "Sincronizar clientas de retoque" para ver quién tiene retoque pendiente.'
         emptyAfterSyncText="No hay clientas con retoque pendiente hoy."
         dismissable
+        onSelectClient={setSelectedClientId}
       />
 
       <ReminderCampaignPanel
@@ -414,9 +417,12 @@ Tu experiencia es muy valiosa para nosotras y nos ayuda a seguir creando momento
         emptyBeforeSyncText='Da clic en "Sincronizar clientas nuevas de hoy" para ver quién visitó por primera vez.'
         emptyAfterSyncText="No hay clientas nuevas hoy."
         dismissable
+        onSelectClient={setSelectedClientId}
       />
 
       <ReminderEffectivenessCard />
+
+      <ClientDetailModal clientId={selectedClientId} onClose={() => setSelectedClientId(null)} />
     </div>
   );
 };


### PR DESCRIPTION
## Qué cambia

En las listas de "Clientas con retoque pendiente" y "Clientas nuevas de hoy" (página de Citas), el nombre de la clienta era texto plano. Ahora es clickeable y abre el mismo `ClientDetailModal` (historial de visitas, ingresos, citas y pagos) que ya se usa en la sección de Clientas y en Reactivación — vía un nuevo prop opcional `onSelectClient` en `ReminderCampaignPanel`, componente compartido por ambas listas.

## Verificación local

Probado en `localhost:3011` contra el API local, confirmado visualmente por el usuario: clic en un nombre en ambas listas abre el historial correctamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)