### PR TITLE
feat: agrupar Citas del día en tickets de venta real

### DIFF
--- a/src/components/widgets/ticket-detail-modal.jsx
+++ b/src/components/widgets/ticket-detail-modal.jsx
@@ -1,0 +1,197 @@
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { api } from '../../lib/api';
+import { useApi } from '../../hooks/use-api';
+import Badge from '../ui/badge';
+import DataTable from './data-table';
+
+const money = (v) => '$' + Math.round(v ?? 0).toLocaleString('es-MX');
+
+function fmtDateTime(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString('es-MX', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+const ITEM_COLS = [
+  { key: 'name', label: 'Servicio' },
+  { key: 'provider_name', label: 'Atendió' },
+  { key: 'origen', label: 'Origen' },
+  { key: 'total', label: 'Total', align: 'right' },
+];
+
+// Full breakdown of a single sale (ticket), opened by clicking a ticket row in
+// the Citas day view. `agendaBookingIds` is the set of booking ids scheduled
+// for the day this ticket belongs to — an item whose booking_reference_id
+// isn't in that set was added at checkout (extra service, walk-in add-on),
+// not something that was ever on the agenda.
+const TicketDetailModal = ({ saleId, agendaBookingIds, onClose }) => {
+  const { data: sale, loading } = useApi(() => (saleId ? api.sale(saleId) : Promise.resolve(null)), [saleId]);
+
+  useEffect(() => {
+    if (!saleId) return;
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [saleId, onClose]);
+
+  if (!saleId) return null;
+
+  const items = (sale?.items ?? []).map((it) => ({
+    ...it,
+    inAgenda: it.booking_reference_id != null && (agendaBookingIds?.has(it.booking_reference_id) ?? false),
+  }));
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- backdrop click-to-close; Escape key and the header close button already cover keyboard access
+    <div
+      role="presentation"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(28, 22, 25, 0.5)',
+        zIndex: 300,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        padding: '4vh 16px',
+        overflowY: 'auto',
+        animation: 'zFade 0.2s var(--ease-out)',
+      }}
+    >
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- stops the backdrop's close-on-click from firing when clicking inside the dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--surface-card)',
+          borderRadius: 'var(--radius-lg)',
+          boxShadow: 'var(--shadow-lg)',
+          width: '100%',
+          maxWidth: 640,
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '18px 22px',
+            borderBottom: '1px solid var(--border-subtle)',
+          }}
+        >
+          <div style={{ minWidth: 0 }}>
+            <div
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 'var(--text-xl)',
+                fontWeight: 'var(--fw-medium)',
+                color: 'var(--text-heading)',
+              }}
+            >
+              {loading ? 'Cargando…' : `Ticket ${sale?.internal_id ?? sale?.id ?? ''}`}
+            </div>
+            <div
+              style={{
+                fontFamily: 'var(--font-sans)',
+                fontSize: 'var(--text-sm)',
+                color: 'var(--text-secondary)',
+                marginTop: 2,
+              }}
+            >
+              {sale ? fmtDateTime(sale.paid_at) : ''}
+              {sale?.client_first_name && (
+                <> · {[sale.client_first_name, sale.client_last_name].filter(Boolean).join(' ')}</>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            title="Cerrar"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 6,
+              color: 'var(--text-muted)',
+              display: 'flex',
+            }}
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div style={{ padding: 22, display: 'flex', flexDirection: 'column', gap: 16 }}>
+          {loading ? (
+            <div style={{ textAlign: 'center', color: 'var(--text-muted)', padding: '16px 0' }}>Cargando…</div>
+          ) : !sale ? (
+            <div style={{ textAlign: 'center', color: 'var(--text-muted)', padding: '16px 0' }}>
+              No se pudo cargar este ticket.
+            </div>
+          ) : (
+            <>
+              <DataTable
+                columns={ITEM_COLS}
+                rows={items}
+                renderCell={(row, key) => {
+                  if (key === 'provider_name') return row.provider_name ?? '—';
+                  if (key === 'origen')
+                    return row.inAgenda ? (
+                      <Badge tone="positive" size="sm" dot>
+                        Agenda
+                      </Badge>
+                    ) : (
+                      <Badge tone="neutral" size="sm">
+                        Agregado en caja
+                      </Badge>
+                    );
+                  if (key === 'total') return money(row.total);
+                  return row[key] ?? '—';
+                }}
+              />
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'flex-end',
+                  gap: 10,
+                  alignItems: 'baseline',
+                  paddingTop: 10,
+                  borderTop: '1px solid var(--border-subtle)',
+                }}
+              >
+                <span
+                  style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}
+                >
+                  Total del ticket
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-display)',
+                    fontSize: 'var(--text-xl)',
+                    fontWeight: 600,
+                    color: 'var(--text-display)',
+                  }}
+                >
+                  {money(sale.total_amount)}
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TicketDetailModal;

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -58,6 +58,8 @@ export const api = {
   paymentMethodsBreakdown: (params) => get('/analytics/payment-methods-breakdown', params),
   clientRetention: (params) => get('/analytics/client-retention', params),
   clientStats: (params) => get('/analytics/client-stats', params),
+  dayTickets: (params) => get('/analytics/day-tickets', params),
+  dayTicketConflicts: (params) => get('/analytics/day-tickets/conflicts', params),
 
   // analytics — new endpoints (to be implemented in zenya-api)
   healthScore: (params) => get('/analytics/health-score', params),
@@ -80,6 +82,7 @@ export const api = {
 
   // resources
   sales: (params) => get('/sales', params),
+  sale: (saleId) => get(`/sales/${saleId}`),
   salesSummary: (params) => get('/sales/summary', params),
   bookings: (params) => get('/bookings', params),
   clients: (params) => get('/clients', params),

--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -9,8 +9,9 @@ import AppointmentReminders from '../components/widgets/appointment-reminders';
 import ReminderCampaignPanel from '../components/widgets/reminder-campaign-panel';
 import ReminderEffectivenessCard from '../components/widgets/reminder-effectiveness-card';
 import ClientDetailModal from '../components/widgets/client-detail-modal';
+import TicketDetailModal from '../components/widgets/ticket-detail-modal';
 import Badge from '../components/ui/badge';
-import { ChevronLeft, ChevronRight, CheckCircle, Clock, XCircle } from 'lucide-react';
+import { ChevronLeft, ChevronRight, CheckCircle, Clock, XCircle, AlertTriangle } from 'lucide-react';
 
 const PAYMENT_ICON_CARDS = [
   { key: 'paid', label: 'Pagadas', icon: CheckCircle, bg: 'var(--positive-soft)', iconColor: 'var(--positive)' },
@@ -60,6 +61,18 @@ const MiniCalendar = ({ selectedDate, onSelect }) => {
   const month = viewDate.getMonth();
   const firstDay = new Date(year, month, 1).getDay();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const pad2 = (n) => String(n).padStart(2, '0');
+  const monthStart = `${year}-${pad2(month + 1)}-01`;
+  const monthEnd = `${year}-${pad2(month + 1)}-${pad2(daysInMonth)}`;
+
+  // Which days this month have a paid ticket with no matching booking at all —
+  // always computed live, so a day stops showing red on its own once the
+  // orphan sale is fixed/removed in AgendaPro and the next sync lands.
+  const { data: conflictData } = useApi(
+    () => api.dayTicketConflicts({ from_date: monthStart, to_date: monthEnd }),
+    [monthStart, monthEnd]
+  );
+  const conflictDates = useMemo(() => new Set(conflictData?.conflicting_dates ?? []), [conflictData]);
 
   const cells = [];
   for (let i = 0; i < firstDay; i++) cells.push(null);
@@ -69,6 +82,7 @@ const MiniCalendar = ({ selectedDate, onSelect }) => {
   const selDate = parseLocalDate(selectedDate);
   const isSelected = (d) => d === selDate.getDate() && month === selDate.getMonth() && year === selDate.getFullYear();
   const isToday = (d) => d === today.getDate() && month === today.getMonth() && year === today.getFullYear();
+  const hasConflict = (d) => d != null && conflictDates.has(`${year}-${pad2(month + 1)}-${pad2(d)}`);
 
   return (
     <div>
@@ -139,20 +153,30 @@ const MiniCalendar = ({ selectedDate, onSelect }) => {
               }
             }}
             disabled={!d}
+            title={hasConflict(d) ? 'Hay un ticket cobrado sin cita asociada este día' : undefined}
             style={{
+              position: 'relative',
               textAlign: 'center',
               fontFamily: 'var(--font-sans)',
               fontSize: 'var(--text-xs)',
-              fontWeight: isToday(d) || isSelected(d) ? 'var(--fw-bold)' : 'var(--fw-regular)',
+              fontWeight: isToday(d) || isSelected(d) || hasConflict(d) ? 'var(--fw-bold)' : 'var(--fw-regular)',
               color: isSelected(d)
                 ? 'var(--white)'
-                : isToday(d)
-                  ? 'var(--brand-primary)'
-                  : d
-                    ? 'var(--text-body)'
+                : hasConflict(d)
+                  ? 'var(--negative)'
+                  : isToday(d)
+                    ? 'var(--brand-primary)'
+                    : d
+                      ? 'var(--text-body)'
+                      : 'transparent',
+              background: isSelected(d)
+                ? 'var(--brand-primary)'
+                : hasConflict(d)
+                  ? 'var(--negative-soft)'
+                  : isToday(d)
+                    ? 'var(--rose-100)'
                     : 'transparent',
-              background: isSelected(d) ? 'var(--brand-primary)' : isToday(d) ? 'var(--rose-100)' : 'transparent',
-              border: 'none',
+              border: isSelected(d) && hasConflict(d) ? '2px solid var(--negative)' : 'none',
               borderRadius: 6,
               padding: '5px 0',
               cursor: d ? 'pointer' : 'default',
@@ -169,15 +193,18 @@ const MiniCalendar = ({ selectedDate, onSelect }) => {
 const Appointments = () => {
   const [selectedDate, setSelectedDate] = useState(localToday);
   const [selectedClientId, setSelectedClientId] = useState(null);
+  const [selectedTicketSaleId, setSelectedTicketSaleId] = useState(null);
   const { data: bookings, loading } = useApi(
     () => api.bookings({ from_date: selectedDate, to_date: selectedDate, limit: 200 }),
     [selectedDate]
   );
   const { data: profList } = useApi(() => api.professionals(), []);
-  // Real revenue for the day comes from actual sales (accounts for discounts /
-  // services added at checkout), not from the amount each booking was scheduled at.
-  const { data: revenueDay, loading: revenueLoading } = useApi(
-    () => api.revenueByDay({ from_date: selectedDate, to_date: selectedDate }),
+  // Groups the day's bookings that share a checkout (cart_id) into a single
+  // ticket with the sale's real total — accounts for discounts and services
+  // added at checkout that a per-booking amount sum would miss — and flags
+  // any sale for the day that isn't tied to a single scheduled booking at all.
+  const { data: dayTickets, loading: ticketsLoading } = useApi(
+    () => api.dayTickets({ date: selectedDate }),
     [selectedDate]
   );
 
@@ -203,8 +230,59 @@ const Appointments = () => {
   const paid = rows.filter((r) => r.payment_status === 'ASSOCIATED' || r.status === 'paid').length;
   const unpaid = rows.filter((r) => !r.payment_status || r.payment_status === 'UNPAID').length;
   const pending = rows.length - paid - unpaid;
-  const totalRev = (revenueDay ?? []).reduce((s, d) => s + (d.revenue ?? 0), 0);
+  const totalRev = dayTickets?.revenue_total ?? 0;
   const paymentCounts = { paid, pending: Math.max(0, pending), unpaid };
+
+  // Every booking id belonging to a ticket (used both to drop those bookings
+  // from the individual-row list below and, inside the ticket detail modal,
+  // to tell agenda-matched items apart from checkout add-ons).
+  const agendaBookingIds = useMemo(() => {
+    const set = new Set();
+    (dayTickets?.tickets ?? []).forEach((t) => t.booking_ids.forEach((id) => set.add(id)));
+    return set;
+  }, [dayTickets]);
+
+  const ticketRows = useMemo(
+    () =>
+      (dayTickets?.tickets ?? []).map((t) => ({
+        key: `ticket-${t.cart_id}`,
+        isTicket: true,
+        saleId: t.sale_id,
+        sortTime: t.time,
+        time: t.time ? new Date(t.time).toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit' }) : '—',
+        service: t.agenda_services.join(', ') || '—',
+        professional: t.professionals.join(', ') || '—',
+        status: 'paid',
+        total: t.total,
+      })),
+    [dayTickets, profNames]
+  );
+
+  // Bookings not swept into a ticket — unpaid/pending citas, or a cart_id
+  // AgendaPro hasn't finalized a sale for yet — keep showing individually.
+  const looseRows = useMemo(
+    () =>
+      rows
+        .filter((r) => !agendaBookingIds.has(r.id))
+        .map((r) => ({
+          key: `booking-${r.id}`,
+          isTicket: false,
+          sortTime: r.start,
+          time: r.time,
+          service: r.service_name ?? '—',
+          professional: r.professional,
+          status: r.status,
+          total: r.amount ?? 0,
+        })),
+    [rows, agendaBookingIds]
+  );
+
+  const combinedRows = useMemo(
+    () => [...ticketRows, ...looseRows].sort((a, b) => new Date(a.sortTime || 0) - new Date(b.sortTime || 0)),
+    [ticketRows, looseRows]
+  );
+
+  const conflictingTickets = dayTickets?.conflicting_tickets ?? [];
 
   const displayDate = parseLocalDate(selectedDate).toLocaleDateString('es-MX', {
     day: '2-digit',
@@ -282,16 +360,50 @@ const Appointments = () => {
         />
         <StatCard
           label="Ingresos del día"
-          value={revenueLoading ? '…' : money(totalRev)}
+          value={ticketsLoading ? '…' : money(totalRev)}
           caption="citas con pago"
           icon="DollarSign"
         />
         <StatCard label="Pendientes" value={loading ? '…' : String(pending)} caption={`${paid} pagadas`} icon="Clock" />
       </div>
 
+      {!ticketsLoading && conflictingTickets.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 12,
+            padding: '14px 16px',
+            borderRadius: 'var(--radius-lg)',
+            background: 'var(--negative-soft)',
+            border: '1px solid var(--negative)',
+          }}
+        >
+          <AlertTriangle size={18} strokeWidth={1.8} color="var(--negative)" style={{ flexShrink: 0, marginTop: 1 }} />
+          <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}>
+            <strong style={{ color: 'var(--negative)' }}>
+              {conflictingTickets.length === 1
+                ? 'Hay un ticket cobrado que no coincide con ninguna cita en la agenda'
+                : `Hay ${conflictingTickets.length} tickets cobrados que no coinciden con ninguna cita en la agenda`}
+            </strong>
+            <div style={{ marginTop: 4 }}>
+              {conflictingTickets.map((c) => (
+                <div key={c.sale_id}>
+                  Ticket {c.internal_id ?? c.sale_id} — {money(c.total)}
+                </div>
+              ))}
+            </div>
+            <div style={{ marginTop: 4, color: 'var(--text-muted)' }}>
+              Revísalo directamente en AgendaPro — el dinero se cobró pero no está ligado a ninguna cita agendada este
+              día.
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="z-appt-layout">
         <Card eyebrow="Agenda" title={`Citas — ${displayDate}`}>
-          {loading ? (
+          {loading || ticketsLoading ? (
             <div
               style={{
                 padding: '20px 0',
@@ -303,14 +415,28 @@ const Appointments = () => {
             >
               Cargando...
             </div>
-          ) : rows.length ? (
+          ) : combinedRows.length ? (
             <DataTable
               columns={APPT_COLS}
-              rows={rows}
+              rows={combinedRows}
               renderCell={(row, key) => {
-                if (key === 'service') return row.service_name ?? '—';
+                if (key === 'service') {
+                  const label = row.service.length > 46 ? row.service.slice(0, 46) + '…' : row.service;
+                  return row.isTicket ? (
+                    <button
+                      type="button"
+                      className="z-client-name"
+                      title="Ver desglose del ticket"
+                      onClick={() => setSelectedTicketSaleId(row.saleId)}
+                    >
+                      {label}
+                    </button>
+                  ) : (
+                    <span title={row.service}>{label}</span>
+                  );
+                }
                 if (key === 'status') return <ApptStatus status={row.status} />;
-                if (key === 'total') return money(row.sale_total_amount ?? row.amount ?? 0);
+                if (key === 'total') return money(row.total);
                 return row[key];
               }}
             />
@@ -423,6 +549,11 @@ Tu experiencia es muy valiosa para nosotras y nos ayuda a seguir creando momento
       <ReminderEffectivenessCard />
 
       <ClientDetailModal clientId={selectedClientId} onClose={() => setSelectedClientId(null)} />
+      <TicketDetailModal
+        saleId={selectedTicketSaleId}
+        agendaBookingIds={agendaBookingIds}
+        onClose={() => setSelectedTicketSaleId(null)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Qué cambia

En la sección de Citas, dos (o más) citas pagadas en el mismo checkout (mismo `cart_id`) ahora se muestran como **un solo ticket** — hora de la primera cita, quién atendió (resuelto también para las cuentas compartidas Lashes y Cejas / Cosmetología), servicios que sí están agendados, y el total real de la venta — en lugar de una fila duplicada por cada cita con el mismo total.

Clic en el ticket → desglose completo de todos los servicios de esa venta, marcando cuáles vienen de la agenda y cuáles se agregaron en caja.

Detección de conflictos: si una venta pagada ese día no corresponde a ninguna cita agendada, aparece un banner rojo con el ticket exacto, y el día completo se pinta de rojo en el mini-calendario (para cualquier día del mes visible con ese problema) — calculado en vivo, sin caché, así que desaparece solo en cuanto se corrija en AgendaPro.

Requiere el backend de `zenya-api` PR #57 (ya mergeado y desplegado a stage).

## Verificación local

Probado en `localhost:3011` contra `localhost:8011`, confirmado visualmente por el usuario:
- Ticket 1210 del 1 de agosto se muestra una sola vez con sus 2 servicios.
- Banner rojo + calendario en rojo para los días 1, 3 y 4 de agosto (tickets huérfanos reales en los datos).
- Ticket de Cosmetología resuelto a "Bety" en vez del nombre de la cuenta compartida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)