### PR TITLE
Historial de pagos + enlazar anomalías de ticket a su detalle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import NotificationBell from './components/widgets/notification-bell';
 import Login from './pages/login';
 import Overview from './pages/overview';
 import Revenue from './pages/revenue';
+import Payments from './pages/payments';
 import Services from './pages/services';
 import Staff from './pages/staff';
 import Clients from './pages/clients';
@@ -23,6 +24,7 @@ import SettingsPage from './pages/settings';
 const NAV = [
   { id: 'overview', label: 'Resumen', icon: 'LayoutDashboard' },
   { id: 'revenue', label: 'Ingresos', icon: 'TrendingUp' },
+  { id: 'payments', label: 'Pagos', icon: 'Receipt' },
   { id: 'services', label: 'Servicios', icon: 'Sparkles' },
   { id: 'staff', label: 'Personal', icon: 'Users' },
   { id: 'clients', label: 'Clientas', icon: 'Heart' },
@@ -34,6 +36,7 @@ const NAV = [
 const PAGE_META = {
   overview: { eyebrow: 'Dashboard', title: 'Resumen general', subtitle: 'Vista consolidada del negocio' },
   revenue: { eyebrow: 'Finanzas', title: 'Ingresos', subtitle: 'Análisis de ventas y tendencias' },
+  payments: { eyebrow: 'Finanzas', title: 'Historial de pagos', subtitle: 'Todos los tickets de venta del período' },
   services: { eyebrow: 'Catálogo', title: 'Servicios', subtitle: 'Rendimiento por servicio' },
   staff: { eyebrow: 'Equipo', title: 'Personal', subtitle: 'Métricas de desempeño' },
   clients: { eyebrow: 'CRM', title: 'Clientas', subtitle: 'Base de datos y segmentación' },
@@ -47,6 +50,7 @@ const HIDE_RANGE = new Set(['settings', 'appointments', 'gastos']);
 const PAGE_MAP = {
   overview: Overview,
   revenue: Revenue,
+  payments: Payments,
   services: Services,
   staff: Staff,
   clients: Clients,

--- a/src/components/widgets/sale-detail-modal.jsx
+++ b/src/components/widgets/sale-detail-modal.jsx
@@ -1,0 +1,309 @@
+import { useEffect } from 'react';
+import { X, MapPin, User, StickyNote, Gift } from 'lucide-react';
+import Avatar from '../ui/avatar';
+import Badge from '../ui/badge';
+import IconButton from '../ui/icon-button';
+import DataTable from './data-table';
+
+const money = (v) => '$' + Math.round(v ?? 0).toLocaleString('es-MX');
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('es-MX', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function fmtTime(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit' });
+}
+
+// Same "cash"/"debit_card"/... AgendaPro payment method codes used in
+// pages/revenue.jsx's breakdown — kept local since it's a small, page-specific label map.
+const METHOD_LABELS = {
+  cash: 'Efectivo',
+  debit_card: 'Tarjeta débito',
+  credit_card: 'Tarjeta crédito',
+  pos: 'Terminal (POS)',
+  wire_transfer: 'Transferencia',
+};
+
+function methodLabel(method) {
+  if (!method) return '—';
+  return METHOD_LABELS[method] ?? method;
+}
+
+// Same rule as pages/clients.jsx's client-detail-modal: canceled first, then
+// whether anything is still owed, otherwise fully paid.
+function saleStatusBadge(sale) {
+  if (sale.status === 'canceled')
+    return (
+      <Badge tone="neutral" size="sm">
+        Cancelada
+      </Badge>
+    );
+  if ((sale.pending_amount ?? 0) > 0)
+    return (
+      <Badge tone="caution" size="sm" dot>
+        Pendiente
+      </Badge>
+    );
+  return (
+    <Badge tone="positive" size="sm" dot>
+      Pagada
+    </Badge>
+  );
+}
+
+const MiniStat = ({ label, value, tone }) => (
+  <div
+    style={{
+      background: 'var(--surface-sunken)',
+      borderRadius: 'var(--radius-sm)',
+      padding: '12px 14px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 4,
+      minWidth: 0,
+    }}
+  >
+    <div
+      style={{
+        fontFamily: 'var(--font-label)',
+        fontSize: 10,
+        fontWeight: 600,
+        letterSpacing: 'var(--ls-label)',
+        textTransform: 'uppercase',
+        color: 'var(--text-muted)',
+      }}
+    >
+      {label}
+    </div>
+    <div
+      style={{
+        fontFamily: 'var(--font-display)',
+        fontSize: 'var(--text-xl)',
+        fontWeight: 'var(--fw-medium)',
+        color: tone === 'caution' ? 'var(--caution)' : 'var(--text-display)',
+        lineHeight: 'var(--lh-tight)',
+      }}
+    >
+      {value}
+    </div>
+  </div>
+);
+
+const SectionLabel = ({ children }) => (
+  <div
+    style={{
+      fontFamily: 'var(--font-label)',
+      fontSize: 11,
+      fontWeight: 600,
+      letterSpacing: 'var(--ls-label)',
+      textTransform: 'uppercase',
+      color: 'var(--text-brand)',
+      marginBottom: 10,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const EmptyState = ({ text }) => (
+  <div
+    style={{
+      padding: '12px 0',
+      textAlign: 'center',
+      color: 'var(--text-muted)',
+      fontFamily: 'var(--font-sans)',
+      fontSize: 'var(--text-sm)',
+    }}
+  >
+    {text}
+  </div>
+);
+
+const DetailRow = ({ icon: Icon, label, value }) =>
+  value ? (
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+      <Icon size={14} strokeWidth={1.8} color="var(--text-muted)" style={{ marginTop: 2, flexShrink: 0 }} />
+      <div>
+        <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+          {label}
+        </div>
+        <div style={{ fontFamily: 'var(--font-sans)', fontSize: 'var(--text-sm)', color: 'var(--text-body)' }}>
+          {value}
+        </div>
+      </div>
+    </div>
+  ) : null;
+
+const ITEM_COLS = [
+  { key: 'name', label: 'Servicio / producto' },
+  { key: 'provider_name', label: 'Atendió' },
+  { key: 'quantity', label: 'Cant.', align: 'right' },
+  { key: 'total', label: 'Total', align: 'right' },
+];
+
+const TX_COLS = [
+  { key: 'paid_at', label: 'Fecha y hora' },
+  { key: 'payment_method', label: 'Método' },
+  { key: 'total', label: 'Monto', align: 'right' },
+];
+
+const SaleDetailModal = ({ sale, onClose }) => {
+  useEffect(() => {
+    if (!sale) return;
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [sale, onClose]);
+
+  if (!sale) return null;
+
+  const clienta = [sale.client_first_name, sale.client_last_name].filter(Boolean).join(' ').trim() || 'Clienta';
+  const vendedora = [sale.user_first_name, sale.user_last_name].filter(Boolean).join(' ').trim();
+  const methods = [...new Set((sale.transactions ?? []).map((t) => t.payment_method).filter(Boolean))];
+  const ticketLabel = sale.internal_id || `#${sale.id}`;
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- backdrop click-to-close; Escape key and the header close button already cover keyboard access
+    <div
+      role="presentation"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(28, 22, 25, 0.5)',
+        zIndex: 300,
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        padding: '4vh 16px',
+        overflowY: 'auto',
+        animation: 'zFade 0.2s var(--ease-out)',
+      }}
+    >
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- stops the backdrop's close-on-click from firing when clicking inside the dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--surface-card)',
+          borderRadius: 'var(--radius-lg)',
+          boxShadow: 'var(--shadow-lg)',
+          width: '100%',
+          maxWidth: 760,
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '18px 22px',
+            borderBottom: '1px solid var(--border-subtle)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
+            <Avatar name={clienta} size="lg" tone="rose" />
+            <div style={{ minWidth: 0 }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  fontFamily: 'var(--font-display)',
+                  fontSize: 'var(--text-xl)',
+                  fontWeight: 'var(--fw-medium)',
+                  color: 'var(--text-heading)',
+                }}
+              >
+                Ticket {ticketLabel}
+                {saleStatusBadge(sale)}
+              </div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 'var(--text-sm)',
+                  color: 'var(--text-secondary)',
+                  marginTop: 2,
+                }}
+              >
+                {clienta} · {fmtDate(sale.paid_at)} {fmtTime(sale.paid_at)}
+              </div>
+            </div>
+          </div>
+          <IconButton icon={X} size="md" variant="ghost" title="Cerrar" onClick={onClose} />
+        </div>
+
+        <div style={{ padding: 22, display: 'flex', flexDirection: 'column', gap: 24 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 10 }}>
+            <MiniStat label="Total del ticket" value={money(sale.total_amount)} />
+            <MiniStat label="Total pagado" value={money(sale.paid_amount)} />
+            {(sale.pending_amount ?? 0) > 0 && (
+              <MiniStat label="Pendiente" value={money(sale.pending_amount)} tone="caution" />
+            )}
+            {(sale.giftcard_amount ?? 0) > 0 && <MiniStat label="Con giftcard" value={money(sale.giftcard_amount)} />}
+          </div>
+
+          <div>
+            <SectionLabel>Servicios y productos</SectionLabel>
+            {sale.items?.length ? (
+              <DataTable
+                columns={ITEM_COLS}
+                rows={sale.items}
+                renderCell={(row, key) => {
+                  if (key === 'name') return row.name ?? '—';
+                  if (key === 'provider_name') return row.provider_name ?? '—';
+                  if (key === 'quantity') return row.quantity ?? 1;
+                  if (key === 'total') return money(row.total);
+                  return row[key] ?? '—';
+                }}
+              />
+            ) : (
+              <EmptyState text="Sin servicios ni productos registrados en este ticket." />
+            )}
+          </div>
+
+          <div>
+            <SectionLabel>Pagos registrados</SectionLabel>
+            {sale.transactions?.length ? (
+              <DataTable
+                columns={TX_COLS}
+                rows={sale.transactions}
+                renderCell={(row, key) => {
+                  if (key === 'paid_at') return `${fmtDate(row.paid_at)} ${fmtTime(row.paid_at)}`;
+                  if (key === 'payment_method') return methodLabel(row.payment_method);
+                  if (key === 'total') return money(row.total);
+                  return row[key] ?? '—';
+                }}
+              />
+            ) : (
+              <EmptyState text="Sin pagos registrados." />
+            )}
+          </div>
+
+          <div>
+            <SectionLabel>Otros detalles</SectionLabel>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 14 }}>
+              <DetailRow icon={User} label="Atendió / vendió" value={vendedora || null} />
+              <DetailRow icon={MapPin} label="Sucursal" value={sale.location_name} />
+              <DetailRow
+                icon={Gift}
+                label="Método(s) de pago"
+                value={methods.length ? methods.map(methodLabel).join(', ') : null}
+              />
+              <DetailRow icon={StickyNote} label="Nota" value={sale.note} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SaleDetailModal;

--- a/src/lib/icons.js
+++ b/src/lib/icons.js
@@ -56,6 +56,7 @@ import {
   Loader,
   Scissors,
   Palette,
+  Receipt,
 } from 'lucide-react';
 
 const ICON_MAP = {
@@ -116,6 +117,7 @@ const ICON_MAP = {
   Loader,
   Scissors,
   Palette,
+  Receipt,
 };
 
 export const getIcon = (name) => ICON_MAP[name] || null;

--- a/src/pages/appointments.jsx
+++ b/src/pages/appointments.jsx
@@ -386,16 +386,24 @@ const Appointments = () => {
                 ? 'Hay un ticket cobrado que no coincide con ninguna cita en la agenda'
                 : `Hay ${conflictingTickets.length} tickets cobrados que no coinciden con ninguna cita en la agenda`}
             </strong>
-            <div style={{ marginTop: 4 }}>
+            <div style={{ marginTop: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
               {conflictingTickets.map((c) => (
                 <div key={c.sale_id}>
-                  Ticket {c.internal_id ?? c.sale_id} — {money(c.total)}
+                  <button
+                    type="button"
+                    className="z-client-name"
+                    title="Ver detalle del ticket"
+                    onClick={() => setSelectedTicketSaleId(c.sale_id)}
+                  >
+                    Ticket {c.internal_id ?? c.sale_id}
+                  </button>{' '}
+                  — {money(c.total)}
                 </div>
               ))}
             </div>
             <div style={{ marginTop: 4, color: 'var(--text-muted)' }}>
-              Revísalo directamente en AgendaPro — el dinero se cobró pero no está ligado a ninguna cita agendada este
-              día.
+              Haz clic en un ticket para ver su detalle — el dinero se cobró pero no está ligado a ninguna cita agendada
+              este día.
             </div>
           </div>
         </div>

--- a/src/pages/payments.jsx
+++ b/src/pages/payments.jsx
@@ -1,0 +1,233 @@
+import { useState, useMemo } from 'react';
+import { api } from '../lib/api';
+import { useApi } from '../hooks/use-api';
+import Card from '../components/ui/card';
+import Badge from '../components/ui/badge';
+import Select from '../components/ui/select';
+import StatCard from '../components/widgets/stat-card';
+import DataTable from '../components/widgets/data-table';
+import Pagination from '../components/ui/pagination';
+import { usePagination } from '../hooks/use-pagination';
+import SaleDetailModal from '../components/widgets/sale-detail-modal';
+
+const money = (v) => '$' + Math.round(v ?? 0).toLocaleString('es-MX');
+
+// Sales in a given range rarely exceed a few hundred for this salon, but a
+// wide preset (e.g. "Este año") can climb into the low thousands — fetch
+// generously and warn if we still hit the ceiling (see truncated below).
+const FETCH_LIMIT = 2000;
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('es-MX', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function fmtTime(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit' });
+}
+
+function saleStatus(sale) {
+  if (sale.status === 'canceled') return 'canceled';
+  if ((sale.pending_amount ?? 0) > 0) return 'pending';
+  return 'paid';
+}
+
+function statusBadge(status) {
+  if (status === 'canceled')
+    return (
+      <Badge tone="neutral" size="sm">
+        Cancelada
+      </Badge>
+    );
+  if (status === 'pending')
+    return (
+      <Badge tone="caution" size="sm" dot>
+        Pendiente
+      </Badge>
+    );
+  return (
+    <Badge tone="positive" size="sm" dot>
+      Pagada
+    </Badge>
+  );
+}
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'Todos los estados' },
+  { value: 'paid', label: 'Pagadas' },
+  { value: 'pending', label: 'Pendientes' },
+  { value: 'canceled', label: 'Canceladas' },
+];
+
+const COLUMNS = [
+  { key: 'ticket', label: 'Ticket' },
+  { key: 'fecha', label: 'Fecha' },
+  { key: 'hora', label: 'Hora' },
+  { key: 'clienta', label: 'Clienta' },
+  { key: 'monto', label: 'Monto', align: 'right' },
+  { key: 'estado', label: 'Estado' },
+];
+
+const Payments = ({ dateRange }) => {
+  const deps = [dateRange.from_date, dateRange.to_date];
+  const { data: sales, loading } = useApi(() => api.sales({ ...dateRange, limit: FETCH_LIMIT }), deps);
+  const { data: summary } = useApi(() => api.salesSummary(dateRange), deps);
+
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [selectedSale, setSelectedSale] = useState(null);
+
+  const truncated = (sales?.length ?? 0) >= FETCH_LIMIT && (summary?.total_sales ?? 0) > FETCH_LIMIT;
+
+  const rows = useMemo(() => {
+    // Accept the ticket ID with or without its leading "#" (internal_id comes
+    // back from AgendaPro as e.g. "#3013"), plus the underlying numeric id.
+    const term = search.trim().toLowerCase().replace(/^#/, '');
+    return (sales ?? [])
+      .map((s) => ({
+        ...s,
+        clienta: [s.client_first_name, s.client_last_name].filter(Boolean).join(' ').trim() || '—',
+        _status: saleStatus(s),
+      }))
+      .filter((s) => (statusFilter === 'all' ? true : s._status === statusFilter))
+      .filter((s) => {
+        if (!term) return true;
+        const ticketId = (s.internal_id || '').toLowerCase().replace(/^#/, '');
+        return s.clienta.toLowerCase().includes(term) || ticketId.includes(term) || String(s.id).includes(term);
+      });
+  }, [sales, search, statusFilter]);
+
+  const pagination = usePagination(rows.length, 25, `${statusFilter}|${search}`);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20, animation: 'zFade 0.3s var(--ease-out)' }}>
+      <div className="z-kpi-grid">
+        <StatCard label="Tickets del período" value={summary ? summary.total_sales : '—'} icon="Receipt" />
+        <StatCard label="Facturado" value={summary ? money(summary.total_revenue) : '—'} icon="DollarSign" />
+        <StatCard label="Cobrado" value={summary ? money(summary.total_paid) : '—'} icon="CheckCircle" />
+        <StatCard label="Pendiente de cobro" value={summary ? money(summary.total_pending) : '—'} icon="AlertCircle" />
+      </div>
+
+      <Card
+        eyebrow="Historial"
+        title="Ventas y tickets"
+        info="Cada renglón es un ticket de venta cerrado en el punto de venta. Haz clic en el ticket o la clienta para ver el desglose de servicios y pagos."
+        action={
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+            <input
+              placeholder="Buscar por clienta o ID de ticket..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              style={{
+                padding: '4px 10px',
+                borderRadius: 6,
+                border: '1px solid var(--border-subtle)',
+                fontSize: 'var(--text-sm)',
+                fontFamily: 'var(--font-sans)',
+                background: 'var(--surface-card)',
+                color: 'var(--text-body)',
+                height: 30,
+              }}
+            />
+            <Select size="sm" value={statusFilter} onChange={setStatusFilter} options={STATUS_OPTIONS} />
+          </div>
+        }
+      >
+        {truncated && (
+          <div
+            style={{
+              marginBottom: 12,
+              padding: '8px 12px',
+              borderRadius: 'var(--radius-sm)',
+              background: 'var(--caution-soft)',
+              color: 'var(--caution)',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--text-xs)',
+            }}
+          >
+            Mostrando los primeros {FETCH_LIMIT.toLocaleString('es-MX')} de{' '}
+            {summary.total_sales.toLocaleString('es-MX')} tickets. Acota el rango de fechas para ver el resto.
+          </div>
+        )}
+        {loading ? (
+          <div
+            style={{
+              padding: '20px 0',
+              textAlign: 'center',
+              color: 'var(--text-muted)',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--text-sm)',
+            }}
+          >
+            Cargando...
+          </div>
+        ) : rows.length ? (
+          <>
+            <DataTable
+              columns={COLUMNS}
+              rows={rows}
+              page={pagination.page}
+              pageSize={pagination.pageSize}
+              renderCell={(row, key) => {
+                if (key === 'ticket')
+                  return (
+                    <button
+                      type="button"
+                      className="z-client-name"
+                      title="Ver detalle del ticket"
+                      onClick={() => setSelectedSale(row)}
+                    >
+                      {row.internal_id || `#${row.id}`}
+                    </button>
+                  );
+                if (key === 'fecha') return fmtDate(row.paid_at);
+                if (key === 'hora') return fmtTime(row.paid_at);
+                if (key === 'clienta')
+                  return (
+                    <button
+                      type="button"
+                      className="z-client-name"
+                      title="Ver detalle del ticket"
+                      onClick={() => setSelectedSale(row)}
+                    >
+                      {row.clienta}
+                    </button>
+                  );
+                if (key === 'monto') return <span style={{ fontWeight: 600 }}>{money(row.total_amount)}</span>;
+                if (key === 'estado') return statusBadge(row._status);
+                return row[key] ?? '—';
+              }}
+            />
+            <Pagination
+              page={pagination.page}
+              totalPages={pagination.totalPages}
+              pageSize={pagination.pageSize}
+              hasPrev={pagination.hasPrev}
+              hasNext={pagination.hasNext}
+              rangeLabel={pagination.rangeLabel}
+              onPageChange={pagination.setPage}
+              onPageSizeChange={pagination.setPageSize}
+            />
+          </>
+        ) : (
+          <div
+            style={{
+              padding: '20px 0',
+              textAlign: 'center',
+              color: 'var(--text-muted)',
+              fontFamily: 'var(--font-sans)',
+              fontSize: 'var(--text-sm)',
+            }}
+          >
+            Sin tickets en este período.
+          </div>
+        )}
+      </Card>
+
+      <SaleDetailModal sale={selectedSale} onClose={() => setSelectedSale(null)} />
+    </div>
+  );
+};
+
+export default Payments;


### PR DESCRIPTION
## Resumen

**Nueva sección "Pagos"** (usa el selector de fechas global):
- Tarjetas resumen: tickets del período, facturado, cobrado, pendiente de cobro.
- Tabla de tickets: folio, fecha, hora, clienta, monto, estado (Pagada/Pendiente/Cancelada) — buscador por clienta o ID de ticket, filtro por estado, paginación.
- Clic en el folio o la clienta abre un modal con el desglose completo: servicios/productos pagados (quién atendió), pagos registrados (útil si el ticket se pagó en varias partes), y otros detalles (vendedora, sucursal, método(s) de pago, nota).
- No requirió cambios en `zenya-api` — `GET /sales` ya traía folio, montos, clienta, items y transacciones para el rango.

**Citas — anomalías de pago clickeables**: en el aviso rojo de "tickets cobrados que no coinciden con ninguna cita en la agenda", cada ticket listado ahora abre el `TicketDetailModal` que ya usan las filas de tickets del día normal, en vez de solo decir "revísalo en AgendaPro".

Complementa [zenya-api#61](https://github.com/zenya-nails-spa/zenya-api/pull/61) (ya mergeado y desplegado en stage), que corrigió el filtro de fecha de `/sales` para rangos de un solo día.

## Test plan
- [x] `npm run lint` limpio
- [x] Probado en localhost contra la API con el fix — confirmado visualmente por el usuario: historial de pagos, búsqueda por clienta/ID, rango de un solo día, y el clic en tickets del aviso de anomalías en Citas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)